### PR TITLE
Lint fixes for PLR, PLW, PLC, PUI and TC errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,4 +3,4 @@ repos:
     rev: v0.12.3
     hooks:
       - id: ruff
-        args: [""]
+        args: ["--exit-zero"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -598,6 +598,21 @@ pytest = ">=6.2.5"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
+]
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 description = "YAML parser and emitter for Python"
@@ -954,4 +969,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "1c87af20b623a70bb2ce19cb6051568cce5a4f6d2d7f996799ff0400fac50bbf"
+content-hash = "be2f500ed6d1e0968c6aa0fea3512e7347d60632ec303ad3c1e8de8db6e490db"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,14 @@ ignore = [
     "W191",
     "E501",
     "B011",
+    # too-many-arguments
+    "PLR0913",
+    # collapsible-else-if
+    "PLR5501",
+    # too-many-branches
+    "PLR0912",
+    # too-many-return-statements
+    "PLR0911"
 ]
 
 [tool.ruff.lint.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ astor = ">=0.8.1"
 shortuuid = ">=1.0.11"
 dacite = ">=1.8.1"
 deprecated = ">=1.2.14"
+python-dateutil = "^2.8.2"
 
 [tool.poetry.group.dev.dependencies]
 pylint = ">=2.17.5"

--- a/src/conductor/client/ai/orchestrator.py
+++ b/src/conductor/client/ai/orchestrator.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
-from typing import Optional, List
+from typing import Optional, List, TYPE_CHECKING
 from uuid import uuid4
 
 from typing_extensions import Self
 
-from conductor.client.ai.configuration import LLMProvider, VectorDB
-from conductor.client.ai.integrations import IntegrationConfig
-from conductor.client.configuration.configuration import Configuration
 from conductor.client.http.models.integration_api_update import IntegrationApiUpdate
 from conductor.client.http.models.integration_update import IntegrationUpdate
-from conductor.client.http.models.prompt_template import PromptTemplate
 from conductor.client.http.rest import ApiException
 from conductor.client.orkes_clients import OrkesClients
 
+if TYPE_CHECKING:
+    from conductor.client.http.models.prompt_template import PromptTemplate
+    from conductor.client.configuration.configuration import Configuration
+    from conductor.client.ai.integrations import IntegrationConfig
+    from conductor.client.ai.configuration import LLMProvider, VectorDB
+
+NOT_FOUND_STATUS = 404
 
 class AIOrchestrator:
     def __init__(self, api_configuration: Configuration, prompt_test_workflow_name: str = '') -> Self:
@@ -36,7 +39,7 @@ class AIOrchestrator:
         try:
             return self.prompt_client.get_prompt(template_name)
         except ApiException as e:
-            if e.code == 404:
+            if e.code == NOT_FOUND_STATUS:
                 return None
             raise e
 
@@ -93,7 +96,6 @@ class AIOrchestrator:
             existing_integration_api = self.integration_client.get_integration_api(db_integration_name, index)
             if existing_integration_api is None or overwrite:
                 self.integration_client.save_integration_api(db_integration_name, index, api_details)
-        pass
 
     def get_token_used(self, ai_integration: str) -> dict:
         return self.integration_client.get_token_usage_for_integration_provider(ai_integration)

--- a/src/conductor/client/automator/task_handler.py
+++ b/src/conductor/client/automator/task_handler.py
@@ -66,8 +66,7 @@ class TaskHandler:
         elif not isinstance(workers, list):
             workers = [workers]
         if scan_for_annotated_workers is True:
-            for (task_def_name, domain) in _decorated_functions:
-                record = _decorated_functions[(task_def_name, domain)]
+            for (task_def_name, domain), record in _decorated_functions.items():
                 fn = record['func']
                 worker_id = record['worker_id']
                 poll_interval = record['poll_interval']

--- a/src/conductor/client/automator/utils.py
+++ b/src/conductor/client/automator/utils.py
@@ -110,10 +110,7 @@ def get_value(typ: type, val: object) -> object:
     if typ in simple_types:
         return val
     elif str(typ).startswith('typing.List[') or str(typ).startswith('typing.Set[') or str(typ).startswith('list['):
-        values = []
-        for val in val:
-            converted = get_value(type(val), val)
-            values.append(converted)
+        values = [get_value(type(item), item) for item in val]
         return values
     elif str(typ).startswith('dict[') or str(typ).startswith(
             'typing.Dict[') or str(typ).startswith('requests.structures.CaseInsensitiveDict[') or typ == dict:

--- a/src/conductor/client/configuration/settings/metrics_settings.py
+++ b/src/conductor/client/configuration/settings/metrics_settings.py
@@ -33,5 +33,5 @@ class MetricsSettings:
                 os.mkdir(dir)
             except Exception as e:
                 logger.warning(
-                    'Failed to create metrics temporary folder, reason: ', e)
+                    'Failed to create metrics temporary folder, reason: %s', e)
         self.directory = dir

--- a/src/conductor/client/exceptions/api_exception_handler.py
+++ b/src/conductor/client/exceptions/api_exception_handler.py
@@ -3,12 +3,18 @@ import json
 from conductor.client.exceptions.api_error import APIError, APIErrorCode
 from conductor.client.http.rest import ApiException
 
+BAD_REQUEST_STATUS = 400
+FORBIDDEN_STATUS = 403
+NOT_FOUND_STATUS = 404
+REQUEST_TIMEOUT_STATUS = 408
+CONFLICT_STATUS = 409
+
 STATUS_TO_MESSAGE_DEFAULT_MAPPING = {
-    400: "Invalid request",
-    403: "Access forbidden",
-    404: "Resource not found",
-    408: "Request timed out",
-    409: "Resource exists already",
+    BAD_REQUEST_STATUS: "Invalid request",
+    FORBIDDEN_STATUS: "Access forbidden",
+    NOT_FOUND_STATUS: "Resource not found",
+    REQUEST_TIMEOUT_STATUS: "Request timed out",
+    CONFLICT_STATUS: "Resource exists already",
 }
 
 
@@ -18,20 +24,20 @@ def api_exception_handler(function):
             return function(*args, **kwargs)
         except ApiException as e:
 
-            if e.status == 404:
+            if e.status == NOT_FOUND_STATUS:
                 code = APIErrorCode.NOT_FOUND
-            elif e.status == 403:
+            elif e.status == FORBIDDEN_STATUS:
                 code = APIErrorCode.FORBIDDEN
-            elif e.status == 409:
+            elif e.status == CONFLICT_STATUS:
                 code = APIErrorCode.CONFLICT
-            elif e.status == 400:
+            elif e.status == BAD_REQUEST_STATUS:
                 code = APIErrorCode.BAD_REQUEST
-            elif e.status == 408:
+            elif e.status == REQUEST_TIMEOUT_STATUS:
                 code = APIErrorCode.REQUEST_TIMEOUT
             else:
                 code = APIErrorCode.UNKNOWN
 
-            message = STATUS_TO_MESSAGE_DEFAULT_MAPPING[e.status]
+            message = STATUS_TO_MESSAGE_DEFAULT_MAPPING.get(e.status, "Unknown error")
 
             try:
                 if e.body:

--- a/src/conductor/client/helpers/helper.py
+++ b/src/conductor/client/helpers/helper.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import re
+from dateutil.parser import parse
 
 import six
 from requests.structures import CaseInsensitiveDict
@@ -20,7 +21,7 @@ class ObjectMapper(object):
     PRIMITIVE_TYPES = (float, bool, bytes, six.text_type) + six.integer_types
     NATIVE_TYPES_MAPPING = {
         'int': int,
-        'long': int if six.PY3 else long,  # noqa: F821
+        'long': int if six.PY3 else long,  # noqa: F821, YTT202
         'float': float,
         'str': str,
         'bool': bool,
@@ -30,39 +31,29 @@ class ObjectMapper(object):
     }
 
     def to_json(self, obj):
-
         if obj is None:
             return None
         elif isinstance(obj, self.PRIMITIVE_TYPES):
             return obj
         elif isinstance(obj, list):
-            return [self.to_json(sub_obj)
-                    for sub_obj in obj]
+            return [self.to_json(sub_obj) for sub_obj in obj]
         elif isinstance(obj, tuple):
-            return tuple(self.to_json(sub_obj)
-                         for sub_obj in obj)
+            return tuple(self.to_json(sub_obj) for sub_obj in obj)
         elif isinstance(obj, (datetime.datetime, datetime.date)):
             return obj.isoformat()
-
-        if isinstance(obj, dict) or isinstance(obj, CaseInsensitiveDict):
+        elif isinstance(obj, dict) or isinstance(obj, CaseInsensitiveDict):
             obj_dict = obj
+        elif hasattr(obj, 'attribute_map') and hasattr(obj, 'swagger_types'):
+            obj_dict = {obj.attribute_map[attr]: getattr(obj, attr)
+                    for attr, _ in six.iteritems(obj.swagger_types)
+                    if getattr(obj, attr) is not None}
         else:
-            # Convert model obj to dict except
-            # attributes `swagger_types`, `attribute_map`
-            # and attributes which value is not None.
-            # Convert attribute name to json key in
-            # model definition for request.
-            if hasattr(obj, 'attribute_map') and hasattr(obj, 'swagger_types'):
-                obj_dict = {obj.attribute_map[attr]: getattr(obj, attr)
-                            for attr, _ in six.iteritems(obj.swagger_types)
-                            if getattr(obj, attr) is not None}
-            else:
-                obj_dict = {name: getattr(obj, name)
-                            for name in vars(obj)
-                            if getattr(obj, name) is not None}
+            obj_dict = {name: getattr(obj, name)
+                    for name in vars(obj)
+                    if getattr(obj, name) is not None}
 
         return {key: self.to_json(val)
-                for key, val in six.iteritems(obj_dict)}
+            for key, val in six.iteritems(obj_dict)}
 
     def from_json(self, data, klass):
         return self.__deserialize(data, klass)
@@ -133,7 +124,6 @@ class ObjectMapper(object):
         :return: date.
         """
         try:
-            from dateutil.parser import parse
             return parse(string).date()
         except ImportError:
             return string
@@ -152,7 +142,6 @@ class ObjectMapper(object):
         :return: datetime.
         """
         try:
-            from dateutil.parser import parse
             return parse(string)
         except ImportError:
             return string

--- a/src/conductor/client/integration_client.py
+++ b/src/conductor/client/integration_client.py
@@ -35,65 +35,65 @@ class IntegrationClient(ABC):
     @abstractmethod
     def associate_prompt_with_integration(self, ai_integration:str, model_name:str, prompt_name:str):
         """Associate a prompt with an AI integration and model"""
-        pass
+        ...
 
     @abstractmethod
     def delete_integration_api(self, api_name:str, integration_name:str):
         """Delete a specific integration api for a given integration"""
-        pass
+        ...
 
     def delete_integration(self, integration_name:str):
         """Delete an integration"""
-        pass
+
 
     def get_integration_api(self, api_name:str, integration_name:str) -> IntegrationApi:
-        pass
+        ...
 
     def get_integration_apis(self, integration_name:str) -> List[IntegrationApi]:
-        pass
+        ...
 
     def get_integration(self, integration_name:str) -> Integration:
-        pass
+        ...
 
     def get_integrations(self) -> List[Integration]:
         """Returns the list of all the available integrations"""
-        pass
+
 
     def get_prompts_with_integration(self, ai_integration:str, model_name:str) -> List[PromptTemplate]:
-        pass
+        ...
 
     def get_token_usage_for_integration(self, name, integration_name) -> int:
-        pass
+        ...
 
     def get_token_usage_for_integration_provider(self, name) -> dict:
-        pass
+        ...
 
     def register_token_usage(self, body, name, integration_name):
-        pass
+        ...
 
     def save_integration_api(self, integration_name, api_name, api_details: IntegrationApiUpdate):
-        pass
+        ...
 
     def save_integration(self, integration_name, integration_details: IntegrationUpdate):
-        pass
+        ...
 
     # Tags
 
     def delete_tag_for_integration(self, body, tag_name, integration_name):
         """Delete an integration"""
-        pass
+
 
     def delete_tag_for_integration_provider(self, body, name):
-        pass
+        ...
 
     def put_tag_for_integration(self, body, name, integration_name):
-        pass
+        ...
 
     def put_tag_for_integration_provider(self, body, name):
-        pass
+        ...
 
     def get_tags_for_integration(self, name, integration_name):
-        pass
+        ...
 
     def get_tags_for_integration_provider(self, name):
-        pass
+        ...

--- a/src/conductor/client/orkes/models/access_key.py
+++ b/src/conductor/client/orkes/models/access_key.py
@@ -3,7 +3,7 @@ from typing_extensions import Self
 from conductor.client.orkes.models.access_key_status import AccessKeyStatus
 
 
-class AccessKey:
+class AccessKey:  # noqa: PLW1641
     def __init__(self, id: str, status: AccessKeyStatus, created_at: int) -> Self:
         self._id = id
         self._status = status

--- a/src/conductor/client/orkes/models/created_access_key.py
+++ b/src/conductor/client/orkes/models/created_access_key.py
@@ -1,7 +1,7 @@
 from typing_extensions import Self
 
 
-class CreatedAccessKey:
+class CreatedAccessKey:  # noqa: PLW1641
     def __init__(self, id: str, secret: str) -> Self:
         self._id = id
         self._secret = secret

--- a/src/conductor/client/orkes/models/granted_permission.py
+++ b/src/conductor/client/orkes/models/granted_permission.py
@@ -5,7 +5,7 @@ from typing_extensions import Self
 from conductor.client.http.models.target_ref import TargetRef
 
 
-class GrantedPermission:
+class GrantedPermission:  # noqa: PLW1641
     def __init__(self, target: TargetRef, access: List[str]) -> Self:
         self._target = target
         self._access = access

--- a/src/conductor/client/orkes/orkes_integration_client.py
+++ b/src/conductor/client/orkes/orkes_integration_client.py
@@ -65,25 +65,25 @@ class OrkesIntegrationClient(OrkesBaseClient, IntegrationClient):
         return self.integrationApi.get_token_usage_for_integration_provider(name)
 
     def register_token_usage(self, body, name, integration_name):
-        pass
+        ...
 
     # Tags
 
     def delete_tag_for_integration(self, body, tag_name, integration_name):
         """Delete an integration"""
-        pass
+
 
     def delete_tag_for_integration_provider(self, body, name):
-        pass
+        ...
 
     def put_tag_for_integration(self, body, name, integration_name):
-        pass
+        ...
 
     def put_tag_for_integration_provider(self, body, name):
-        pass
+        ...
 
     def get_tags_for_integration(self, name, integration_name):
-        pass
+        ...
 
     def get_tags_for_integration_provider(self, name):
-        pass
+        ...

--- a/src/conductor/client/schema_client.py
+++ b/src/conductor/client/schema_client.py
@@ -20,32 +20,32 @@ class SchemaClient(ABC):
         """
         Register a new schema.
         """
-        pass
+        ...
 
     @abstractmethod
     def get_schema(self, schema_name: str, version: int) -> SchemaDef:
         """
         Retrieve a schema by its name and version.
         """
-        pass
+        ...
 
     @abstractmethod
     def get_all_schemas(self) -> List[SchemaDef]:
         """
         Retrieve all schemas.
         """
-        pass
+        ...
 
     @abstractmethod
     def delete_schema(self, schema_name: str, version: int) -> None:
         """
         Delete a schema by its name and version.
         """
-        pass
+        ...
 
     @abstractmethod
     def delete_schema_by_name(self, schema_name: str) -> None:
         """
         Delete all the versions of a schema by its name
         """
-        pass
+        ...

--- a/src/conductor/client/worker/worker.py
+++ b/src/conductor/client/worker/worker.py
@@ -38,7 +38,7 @@ def is_callable_input_parameter_a_task(callable: ExecuteTaskFunction, object_typ
     if len(parameters) != 1:
         return False
     parameter = parameters[list(parameters.keys())[0]]
-    return parameter.annotation == object_type or parameter.annotation == parameter.empty or parameter.annotation == object
+    return parameter.annotation in (object_type, parameter.empty, object)
 
 
 def is_callable_return_value_of_type(callable: ExecuteTaskFunction, object_type: Any) -> bool:

--- a/src/conductor/client/worker/worker_interface.py
+++ b/src/conductor/client/worker/worker_interface.py
@@ -25,7 +25,7 @@ class WorkerInterface(abc.ABC):
         :return: TaskResult
                  If the task is not completed yet, return with the status as IN_PROGRESS.
         """
-        pass
+        ...
 
     def get_identity(self) -> str:
         """

--- a/src/conductor/client/workflow/task/task.py
+++ b/src/conductor/client/workflow/task/task.py
@@ -154,11 +154,10 @@ class TaskInterface(ABC):
     def output(self, json_path: str = None) -> str:
         if json_path is None:
             return '${' + f'{self.task_reference_name}.output' + '}'
+        elif json_path.startswith('.'):
+            return '${' + f'{self.task_reference_name}.output{json_path}' + '}'
         else:
-            if json_path.startswith('.'):
-                return '${' + f'{self.task_reference_name}.output{json_path}' + '}'
-            else:
-                return '${' + f'{self.task_reference_name}.output.{json_path}' + '}'
+            return '${' + f'{self.task_reference_name}.output.{json_path}' + '}'
 
     def input(self, json_path: str = None, key : str = None, value : Any = None) -> Union[str, Self]:
         if key is not None and value is not None:
@@ -172,7 +171,7 @@ class TaskInterface(ABC):
         else:
             return '${' + f'{self.task_reference_name}.input.{json_path}' + '}'
 
-    def __getattribute__(self, __name: str) -> Any:
+    def __getattribute__(self, __name: str, /) -> Any:
         try:
             val = super().__getattribute__(__name)
             return val


### PR DESCRIPTION
Changes:

Applied fixes for PLR, PLW, PLC, PYI and TC linter errors:

PLR [Pylint Refactor](https://docs.astral.sh/ruff/rules/#refactor-plr)
PLW [Pylint Warning](https://docs.astral.sh/ruff/rules/#warning-plw)
PLC [Pylint Convention](https://docs.astral.sh/ruff/rules/#convention-plc)
PYI [flake8-pyi](https://docs.astral.sh/ruff/rules/#flake8-pyi-pyi)
TC [flake8-type-checking](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc)

Reason:

Enforcing consistent code style and reducing technical debt.