### PR TITLE
Rewrite serdesertest/ to pytest

### DIFF
--- a/tests/serdesertest/test_serdeser_action.py
+++ b/tests/serdesertest/test_serdeser_action.py
@@ -1,131 +1,114 @@
-import unittest
+import json
+import re
+
+import pytest
+
 from conductor.client.http.models.action import Action
 from conductor.client.http.models.start_workflow import StartWorkflow
 from conductor.client.http.models.task_details import TaskDetails
 from conductor.client.http.models.terminate_workflow import TerminateWorkflow
-from conductor.client.http.models.update_workflow_variables import UpdateWorkflowVariables
+from conductor.client.http.models.update_workflow_variables import (
+    UpdateWorkflowVariables,
+)
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
-import json
-import re
 
 
-class TestActionSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("EventHandler.Action")
-        self.server_json = json.loads(self.server_json_str)
-
-    def _camel_to_snake(self, name):
-        """Convert camelCase to snake_case"""
-        # Insert underscore before uppercase letters and convert to lowercase
-        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
-
-    def _create_model_object(self, model_class, json_data):
-        """Generic method to create model objects with proper camelCase to snake_case conversion"""
-        if not json_data:
-            return None
-
-        # Create an instance of the model class
-        obj = model_class()
-
-        # Iterate through the JSON data and set attributes on the model object
-        for key, value in json_data.items():
-            # Convert camelCase to snake_case
-            snake_key = self._camel_to_snake(key)
-
-            # Try to set the attribute if it exists on the model
-            if hasattr(obj, snake_key):
-                setattr(obj, snake_key, value)
-
-        return obj
-
-    def test_action_serdes(self):
-        # 1. Test deserialization of server JSON to SDK model
-        action_obj = Action(
-            action=self.server_json.get("action"),
-            start_workflow=self._create_model_object(StartWorkflow, self.server_json.get("start_workflow")),
-            complete_task=self._create_model_object(TaskDetails, self.server_json.get("complete_task")),
-            fail_task=self._create_model_object(TaskDetails, self.server_json.get("fail_task")),
-            expand_inline_json=self.server_json.get("expandInlineJSON"),
-            terminate_workflow=self._create_model_object(TerminateWorkflow, self.server_json.get("terminate_workflow")),
-            update_workflow_variables=self._create_model_object(UpdateWorkflowVariables,
-                                                                self.server_json.get("update_workflow_variables"))
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get("action"), action_obj.action)
-
-        # Check if start_workflow exists in the JSON
-        if "start_workflow" in self.server_json:
-            self.assertIsNotNone(action_obj.start_workflow)
-
-        # Check if complete_task exists in the JSON
-        if "complete_task" in self.server_json:
-            self.assertIsNotNone(action_obj.complete_task)
-
-        # Check if fail_task exists in the JSON
-        if "fail_task" in self.server_json:
-            self.assertIsNotNone(action_obj.fail_task)
-
-        # Check if expandInlineJSON exists in the JSON
-        if "expandInlineJSON" in self.server_json:
-            self.assertEqual(self.server_json.get("expandInlineJSON"), action_obj.expand_inline_json)
-
-        # Check if terminate_workflow exists in the JSON
-        if "terminate_workflow" in self.server_json:
-            self.assertIsNotNone(action_obj.terminate_workflow)
-
-        # Check if update_workflow_variables exists in the JSON
-        if "update_workflow_variables" in self.server_json:
-            self.assertIsNotNone(action_obj.update_workflow_variables)
-
-        # 3. Verify the action enum value is valid
-        allowed_values = ["start_workflow", "complete_task", "fail_task", "terminate_workflow",
-                          "update_workflow_variables"]
-        self.assertIn(action_obj.action, allowed_values)
-
-        # 4. Test serialization back to JSON
-        result_json = action_obj.to_dict()
-
-        # 5. Verify the result JSON has the same keys and values as the original
-        for key in self.server_json:
-            if key == "expandInlineJSON":
-                # Handle camelCase to snake_case conversion
-                self.assertEqual(self.server_json[key], result_json["expand_inline_json"])
-            elif key in ["terminate_workflow", "start_workflow", "complete_task", "fail_task",
-                         "update_workflow_variables"]:
-                # For nested objects, verify they exist in result_json
-                if self.server_json[key] is not None:
-                    self.assertIsNotNone(result_json[key])
-
-                    # For terminate_workflow, check specific camelCase fields
-                    if key == "terminate_workflow" and key in result_json:
-                        term_json = self.server_json[key]
-                        result_term = result_json[key]
-
-                        # Maps the expected field names from server JSON to the result JSON
-                        if "workflowId" in term_json and "workflowId" in result_term:
-                            self.assertEqual(term_json["workflowId"], result_term["workflowId"])
-                        if "terminationReason" in term_json and "terminationReason" in result_term:
-                            self.assertEqual(term_json["terminationReason"], result_term["terminationReason"])
-
-                    # For update_workflow_variables, check specific camelCase fields
-                    if key == "update_workflow_variables" and key in result_json:
-                        update_json = self.server_json[key]
-                        result_update = result_json[key]
-
-                        # Maps the expected field names from server JSON to the result JSON
-                        if "workflowId" in update_json and "workflowId" in result_update:
-                            self.assertEqual(update_json["workflowId"], result_update["workflowId"])
-                        if "variables" in update_json and "variables" in result_update:
-                            self.assertEqual(update_json["variables"], result_update["variables"])
-                        if "appendArray" in update_json and "appendArray" in result_update:
-                            self.assertEqual(update_json["appendArray"], result_update["appendArray"])
-            elif key in result_json:
-                # Direct comparison for keys that match
-                self.assertEqual(self.server_json[key], result_json[key])
+def camel_to_snake(name):
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
 
 
-if __name__ == '__main__':
-    unittest.main()
+def create_model_object(model_class, json_data):
+    if not json_data:
+        return None
+    obj = model_class()
+    for key, value in json_data.items():
+        snake_key = camel_to_snake(key)
+        if hasattr(obj, snake_key):
+            setattr(obj, snake_key, value)
+    return obj
+
+
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("EventHandler.Action"))
+
+
+def test_action_serdes(server_json):
+    action_obj = Action(
+        action=server_json.get("action"),
+        start_workflow=create_model_object(
+            StartWorkflow, server_json.get("start_workflow")
+        ),
+        complete_task=create_model_object(
+            TaskDetails, server_json.get("complete_task")
+        ),
+        fail_task=create_model_object(TaskDetails, server_json.get("fail_task")),
+        expand_inline_json=server_json.get("expandInlineJSON"),
+        terminate_workflow=create_model_object(
+            TerminateWorkflow, server_json.get("terminate_workflow")
+        ),
+        update_workflow_variables=create_model_object(
+            UpdateWorkflowVariables, server_json.get("update_workflow_variables")
+        ),
+    )
+    assert server_json.get("action") == action_obj.action
+    if "start_workflow" in server_json:
+        assert action_obj.start_workflow is not None
+    if "complete_task" in server_json:
+        assert action_obj.complete_task is not None
+    if "fail_task" in server_json:
+        assert action_obj.fail_task is not None
+    if "expandInlineJSON" in server_json:
+        assert server_json.get("expandInlineJSON") == action_obj.expand_inline_json
+    if "terminate_workflow" in server_json:
+        assert action_obj.terminate_workflow is not None
+    if "update_workflow_variables" in server_json:
+        assert action_obj.update_workflow_variables is not None
+    allowed_values = [
+        "start_workflow",
+        "complete_task",
+        "fail_task",
+        "terminate_workflow",
+        "update_workflow_variables",
+    ]
+    assert action_obj.action in allowed_values
+    result_json = action_obj.to_dict()
+    for key in server_json:
+        if key == "expandInlineJSON":
+            assert server_json[key] == result_json["expand_inline_json"]
+        elif key in [
+            "terminate_workflow",
+            "start_workflow",
+            "complete_task",
+            "fail_task",
+            "update_workflow_variables",
+        ]:
+            if server_json[key] is not None:
+                assert result_json[key] is not None
+                if key == "terminate_workflow" and key in result_json:
+                    term_json = server_json[key]
+                    result_term = result_json[key]
+                    if "workflowId" in term_json and "workflowId" in result_term:
+                        assert term_json["workflowId"] == result_term["workflowId"]
+                    if (
+                        "terminationReason" in term_json
+                        and "terminationReason" in result_term
+                    ):
+                        assert (
+                            term_json["terminationReason"]
+                            == result_term["terminationReason"]
+                        )
+                if key == "update_workflow_variables" and key in result_json:
+                    update_json = server_json[key]
+                    result_update = result_json[key]
+                    if "workflowId" in update_json and "workflowId" in result_update:
+                        assert update_json["workflowId"] == result_update["workflowId"]
+                    if "variables" in update_json and "variables" in result_update:
+                        assert update_json["variables"] == result_update["variables"]
+                    if "appendArray" in update_json and "appendArray" in result_update:
+                        assert (
+                            update_json["appendArray"] == result_update["appendArray"]
+                        )
+        elif key in result_json:
+            assert server_json[key] == result_json[key]

--- a/tests/serdesertest/test_serdeser_authorization_request.py
+++ b/tests/serdesertest/test_serdeser_authorization_request.py
@@ -1,64 +1,36 @@
-import unittest
 import json
+
+import pytest
+
+from conductor.client.http.models.authorization_request import AuthorizationRequest
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
-# Import the classes being tested
-from conductor.client.http.models.authorization_request import AuthorizationRequest
+
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("AuthorizationRequest"))
 
 
-class TestAuthorizationRequestSerDes(unittest.TestCase):
-    """
-    Unit tests for serialization and deserialization of AuthorizationRequest model.
-    """
-
-    def setUp(self):
-        """Set up test fixtures."""
-        # Load the template JSON for testing
-        self.server_json_str = JsonTemplateResolver.get_json_string("AuthorizationRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_serialization_deserialization(self):
-        """Test complete serialization and deserialization process."""
-        # Create the authorization request object directly from JSON
-        # The model's __init__ should handle the nested objects
-        auth_request = AuthorizationRequest(
-            subject=self.server_json.get('subject'),
-            target=self.server_json.get('target'),
-            access=self.server_json.get('access')
-        )
-
-        # Verify model is properly initialized
-        self.assertIsNotNone(auth_request, "Deserialized object should not be null")
-
-        # Verify access list
-        self.assertIsNotNone(auth_request.access, "Access list should not be null")
-        self.assertTrue(all(access in ["CREATE", "READ", "UPDATE", "DELETE", "EXECUTE"]
-                            for access in auth_request.access))
-
-        # Verify subject and target are present
-        self.assertIsNotNone(auth_request.subject, "Subject should not be null")
-        self.assertIsNotNone(auth_request.target, "Target should not be null")
-
-        # Serialize back to dictionary
-        result_dict = auth_request.to_dict()
-
-        # Verify structure matches the original
-        self.assertEqual(
-            set(self.server_json.keys()),
-            set(result_dict.keys()),
-            "Serialized JSON should have the same keys as the original"
-        )
-
-        # Convert both to JSON strings and compare (similar to objectMapper.readTree)
-        original_json_normalized = json.dumps(self.server_json, sort_keys=True)
-        result_json_normalized = json.dumps(result_dict, sort_keys=True)
-
-        self.assertEqual(
-            original_json_normalized,
-            result_json_normalized,
-            "Serialized JSON should match the original SERVER_JSON"
-        )
-
-
-if __name__ == '__main__':
-    unittest.main()
+def test_serialization_deserialization(server_json):
+    auth_request = AuthorizationRequest(
+        subject=server_json.get("subject"),
+        target=server_json.get("target"),
+        access=server_json.get("access"),
+    )
+    assert auth_request is not None, "Deserialized object should not be null"
+    assert auth_request.access is not None, "Access list should not be null"
+    assert all(
+        access in ["CREATE", "READ", "UPDATE", "DELETE", "EXECUTE"]
+        for access in auth_request.access
+    )
+    assert auth_request.subject is not None, "Subject should not be null"
+    assert auth_request.target is not None, "Target should not be null"
+    result_dict = auth_request.to_dict()
+    assert set(server_json.keys()) == set(
+        result_dict.keys()
+    ), "Serialized JSON should have the same keys as the original"
+    original_json_normalized = json.dumps(server_json, sort_keys=True)
+    result_json_normalized = json.dumps(result_dict, sort_keys=True)
+    assert (
+        original_json_normalized == result_json_normalized
+    ), "Serialized JSON should match the original SERVER_JSON"

--- a/tests/serdesertest/test_serdeser_bulk_response.py
+++ b/tests/serdesertest/test_serdeser_bulk_response.py
@@ -1,106 +1,80 @@
-import unittest
 import json
+
+import pytest
 
 from conductor.client.http.models import BulkResponse
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestBulkResponseSerDeser(unittest.TestCase):
-    """Test serialization and deserialization for BulkResponse class"""
-
-    def setUp(self):
-        """Set up test fixtures"""
-        # Load test data from template
-        self.server_json_str = JsonTemplateResolver.get_json_string("BulkResponse")
-        # Parse into dictionary for comparisons
-        self.server_json_dict = json.loads(self.server_json_str)
-
-    def test_bulk_response_serialization_deserialization(self):
-        """Comprehensive test for serialization and deserialization of BulkResponse"""
-        # 1. Deserialize JSON into model object
-        bulk_response = BulkResponse(
-            bulk_error_results=self.server_json_dict['bulkErrorResults'],
-            bulk_successful_results=self.server_json_dict['bulkSuccessfulResults'],
-            message=self.server_json_dict['message']
-        )
-
-        # 2. Verify BulkResponse object properties and types
-        self.assertIsInstance(bulk_response, BulkResponse)
-        self.assertIsInstance(bulk_response.bulk_error_results, dict)
-        self.assertIsInstance(bulk_response.bulk_successful_results, list)
-
-        # 3. Validate content of properties
-        for key, value in bulk_response.bulk_error_results.items():
-            self.assertIsInstance(key, str)
-            self.assertIsInstance(value, str)
-
-        # Validate the structure of items in bulk_successful_results
-        # This adapts to the actual structure found in the template
-        for item in bulk_response.bulk_successful_results:
-            # If the items are dictionaries with 'value' keys
-            if isinstance(item, dict) and 'value' in item:
-                self.assertIsInstance(item['value'], str)
-            # If the items are strings
-            elif isinstance(item, str):
-                pass
-            else:
-                self.fail(f"Unexpected item type in bulk_successful_results: {type(item)}")
-
-        # 4. Verify values match original source
-        self.assertEqual(bulk_response.bulk_error_results, self.server_json_dict['bulkErrorResults'])
-        self.assertEqual(bulk_response.bulk_successful_results, self.server_json_dict['bulkSuccessfulResults'])
-
-        # 5. Test serialization back to dictionary
-        result_dict = bulk_response.to_dict()
-        self.assertIn('bulk_error_results', result_dict)
-        self.assertIn('bulk_successful_results', result_dict)
-        self.assertEqual(result_dict['bulk_error_results'], self.server_json_dict['bulkErrorResults'])
-        self.assertEqual(result_dict['bulk_successful_results'], self.server_json_dict['bulkSuccessfulResults'])
-
-        # 6. Test serialization to JSON-compatible dictionary (with camelCase keys)
-        json_compatible_dict = {
-            'bulkErrorResults': result_dict['bulk_error_results'],
-            'bulkSuccessfulResults': result_dict['bulk_successful_results'],
-            'message': result_dict['message']
-        }
-
-        # 7. Normalize dictionaries for comparison (handles differences in ordering)
-        normalized_original = json.loads(json.dumps(self.server_json_dict, sort_keys=True))
-        normalized_result = json.loads(json.dumps(json_compatible_dict, sort_keys=True))
-        self.assertEqual(normalized_original, normalized_result)
-
-        # 8. Test full serialization/deserialization round trip
-        bulk_response_2 = BulkResponse(
-            bulk_error_results=result_dict['bulk_error_results'],
-            bulk_successful_results=result_dict['bulk_successful_results'],
-            message=self.server_json_dict['message']
-        )
-        self.assertEqual(bulk_response.bulk_error_results, bulk_response_2.bulk_error_results)
-        self.assertEqual(bulk_response.bulk_successful_results, bulk_response_2.bulk_successful_results)
-
-        # 9. Test with missing fields
-        bulk_response_errors_only = BulkResponse(
-            bulk_error_results={"id1": "error1"}
-        )
-        self.assertEqual(bulk_response_errors_only.bulk_error_results, {"id1": "error1"})
-        self.assertEqual(bulk_response_errors_only.bulk_successful_results, [])
-
-        # Create a structure similar to what's in the template
-        sample_successful_result = [{"value": "success1"}]
-        bulk_response_success_only = BulkResponse(
-            bulk_successful_results=sample_successful_result
-        )
-        self.assertEqual(bulk_response_success_only.bulk_error_results, {})
-        self.assertEqual(bulk_response_success_only.bulk_successful_results, sample_successful_result)
-
-        # 10. Test with empty fields
-        bulk_response_empty = BulkResponse(
-            bulk_error_results={},
-            bulk_successful_results=[]
-        )
-        self.assertEqual(bulk_response_empty.bulk_error_results, {})
-        self.assertEqual(bulk_response_empty.bulk_successful_results, [])
+@pytest.fixture
+def server_json_dict():
+    return json.loads(JsonTemplateResolver.get_json_string("BulkResponse"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_bulk_response_serialization_deserialization(server_json_dict):
+    bulk_response = BulkResponse(
+        bulk_error_results=server_json_dict["bulkErrorResults"],
+        bulk_successful_results=server_json_dict["bulkSuccessfulResults"],
+        message=server_json_dict["message"],
+    )
+    assert isinstance(bulk_response, BulkResponse)
+    assert isinstance(bulk_response.bulk_error_results, dict)
+    assert isinstance(bulk_response.bulk_successful_results, list)
+    for key, value in bulk_response.bulk_error_results.items():
+        assert isinstance(key, str)
+        assert isinstance(value, str)
+    for item in bulk_response.bulk_successful_results:
+        if isinstance(item, dict) and "value" in item:
+            assert isinstance(item["value"], str)
+        elif isinstance(item, str):
+            pass
+        else:
+            pytest.fail(
+                f"Unexpected item type in bulk_successful_results: {type(item)}"
+            )
+    assert bulk_response.bulk_error_results == server_json_dict["bulkErrorResults"]
+    assert (
+        bulk_response.bulk_successful_results
+        == server_json_dict["bulkSuccessfulResults"]
+    )
+    result_dict = bulk_response.to_dict()
+    assert "bulk_error_results" in result_dict
+    assert "bulk_successful_results" in result_dict
+    assert result_dict["bulk_error_results"] == server_json_dict["bulkErrorResults"]
+    assert (
+        result_dict["bulk_successful_results"]
+        == server_json_dict["bulkSuccessfulResults"]
+    )
+    json_compatible_dict = {
+        "bulkErrorResults": result_dict["bulk_error_results"],
+        "bulkSuccessfulResults": result_dict["bulk_successful_results"],
+        "message": result_dict["message"],
+    }
+    normalized_original = json.loads(json.dumps(server_json_dict, sort_keys=True))
+    normalized_result = json.loads(json.dumps(json_compatible_dict, sort_keys=True))
+    assert normalized_original == normalized_result
+    bulk_response_2 = BulkResponse(
+        bulk_error_results=result_dict["bulk_error_results"],
+        bulk_successful_results=result_dict["bulk_successful_results"],
+        message=server_json_dict["message"],
+    )
+    assert bulk_response.bulk_error_results == bulk_response_2.bulk_error_results
+    assert (
+        bulk_response.bulk_successful_results == bulk_response_2.bulk_successful_results
+    )
+    bulk_response_errors_only = BulkResponse(bulk_error_results={"id1": "error1"})
+    assert bulk_response_errors_only.bulk_error_results == {"id1": "error1"}
+    assert bulk_response_errors_only.bulk_successful_results == []
+    sample_successful_result = [{"value": "success1"}]
+    bulk_response_success_only = BulkResponse(
+        bulk_successful_results=sample_successful_result
+    )
+    assert bulk_response_success_only.bulk_error_results == {}
+    assert (
+        bulk_response_success_only.bulk_successful_results == sample_successful_result
+    )
+    bulk_response_empty = BulkResponse(
+        bulk_error_results={}, bulk_successful_results=[]
+    )
+    assert bulk_response_empty.bulk_error_results == {}
+    assert bulk_response_empty.bulk_successful_results == []

--- a/tests/serdesertest/test_serdeser_conductor_application.py
+++ b/tests/serdesertest/test_serdeser_conductor_application.py
@@ -1,46 +1,26 @@
-import unittest
 import json
+
+import pytest
 
 from conductor.client.http.models import ConductorApplication
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-
-class TestConductorApplicationSerialization(unittest.TestCase):
-    """Test case for ConductorApplication serialization and deserialization."""
-
-    def setUp(self):
-        """Set up test fixtures before each test."""
-        # Load JSON template from the resolver utility
-        self.server_json_str = JsonTemplateResolver.get_json_string("ConductorApplication")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_serialization_deserialization(self):
-        """Test that validates the serialization and deserialization of ConductorApplication model."""
-
-        # Step 1: Deserialize server JSON into SDK model object
-        # Create model object using constructor with fields from the JSON
-        conductor_app = ConductorApplication(
-            id=self.server_json.get('id'),
-            name=self.server_json.get('name'),
-            created_by=self.server_json.get('createdBy')
-        )
-
-        # Step 2: Verify all fields are correctly populated
-        self.assertEqual(conductor_app.id, self.server_json.get('id'))
-        self.assertEqual(conductor_app.name, self.server_json.get('name'))
-        self.assertEqual(conductor_app.created_by, self.server_json.get('createdBy'))
-
-        # Step 3: Serialize the model back to JSON
-        serialized_json = conductor_app.to_dict()
-
-        # Step 4: Verify the serialized JSON matches the original
-        # Note: Field names in serialized_json will be in snake_case
-        self.assertEqual(serialized_json.get('id'), self.server_json.get('id'))
-        self.assertEqual(serialized_json.get('name'), self.server_json.get('name'))
-        # Handle the camelCase to snake_case transformation
-        self.assertEqual(serialized_json.get('created_by'), self.server_json.get('createdBy'))
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("ConductorApplication"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_serialization_deserialization(server_json):
+    conductor_app = ConductorApplication(
+        id=server_json.get("id"),
+        name=server_json.get("name"),
+        created_by=server_json.get("createdBy"),
+    )
+    assert conductor_app.id == server_json.get("id")
+    assert conductor_app.name == server_json.get("name")
+    assert conductor_app.created_by == server_json.get("createdBy")
+    serialized_json = conductor_app.to_dict()
+    assert serialized_json.get("id") == server_json.get("id")
+    assert serialized_json.get("name") == server_json.get("name")
+    assert serialized_json.get("created_by") == server_json.get("createdBy")

--- a/tests/serdesertest/test_serdeser_conductor_user.py
+++ b/tests/serdesertest/test_serdeser_conductor_user.py
@@ -1,104 +1,75 @@
 import json
-import unittest
 
-from conductor.client.http.models import ConductorUser, Role, Group
+import pytest
+
+from conductor.client.http.models import ConductorUser, Group, Role
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestConductorUserSerDeSer(unittest.TestCase):
-    """Test serialization and deserialization of ConductorUser."""
-
-    def setUp(self):
-        # Load JSON template using the utility
-        self.server_json_str = JsonTemplateResolver.get_json_string("ConductorUser")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_conductor_user_serde(self):
-        """Test that ConductorUser can be deserialized from server JSON and serialized back without data loss."""
-
-        # 1. Deserialize server JSON into ConductorUser object
-        conductor_user = ConductorUser()
-        conductor_user_dict = self.server_json
-
-        # Set attributes from deserialized JSON
-        if 'id' in conductor_user_dict:
-            conductor_user.id = conductor_user_dict['id']
-        if 'name' in conductor_user_dict:
-            conductor_user.name = conductor_user_dict['name']
-        if 'roles' in conductor_user_dict:
-            # Assuming Role has a from_dict method or similar
-            roles_list = []
-            for role_data in conductor_user_dict['roles']:
-                role = Role()  # Create a Role object based on your actual implementation
-                # Set Role properties here
-                roles_list.append(role)
-            conductor_user.roles = roles_list
-        if 'groups' in conductor_user_dict:
-            # Assuming Group has a from_dict method or similar
-            groups_list = []
-            for group_data in conductor_user_dict['groups']:
-                group = Group()  # Create a Group object based on your actual implementation
-                # Set Group properties here
-                groups_list.append(group)
-            conductor_user.groups = groups_list
-        if 'uuid' in conductor_user_dict:
-            conductor_user.uuid = conductor_user_dict['uuid']
-        if 'applicationUser' in conductor_user_dict:
-            conductor_user.application_user = conductor_user_dict['applicationUser']
-        if 'encryptedId' in conductor_user_dict:
-            conductor_user.encrypted_id = conductor_user_dict['encryptedId']
-        if 'encryptedIdDisplayValue' in conductor_user_dict:
-            conductor_user.encrypted_id_display_value = conductor_user_dict['encryptedIdDisplayValue']
-
-        # 2. Verify all fields are properly populated
-        expected_id = self.server_json.get('id', None)
-        self.assertEqual(conductor_user.id, expected_id)
-
-        expected_name = self.server_json.get('name', None)
-        self.assertEqual(conductor_user.name, expected_name)
-
-        # Verify lists
-        if 'roles' in self.server_json:
-            self.assertEqual(len(conductor_user.roles), len(self.server_json['roles']))
-
-        if 'groups' in self.server_json:
-            self.assertEqual(len(conductor_user.groups), len(self.server_json['groups']))
-
-        expected_uuid = self.server_json.get('uuid', None)
-        self.assertEqual(conductor_user.uuid, expected_uuid)
-
-        expected_app_user = self.server_json.get('applicationUser', None)
-        self.assertEqual(conductor_user.application_user, expected_app_user)
-
-        expected_encrypted_id = self.server_json.get('encryptedId', None)
-        self.assertEqual(conductor_user.encrypted_id, expected_encrypted_id)
-
-        expected_encrypted_id_display = self.server_json.get('encryptedIdDisplayValue', None)
-        self.assertEqual(conductor_user.encrypted_id_display_value, expected_encrypted_id_display)
-
-        # 3. Serialize the object back to JSON
-        serialized_json = conductor_user.to_dict()
-
-        # 4. Verify the serialized JSON matches the original
-        # Handle camelCase to snake_case transformations
-        if 'applicationUser' in self.server_json:
-            self.assertEqual(serialized_json['application_user'], self.server_json['applicationUser'])
-        if 'encryptedId' in self.server_json:
-            self.assertEqual(serialized_json['encrypted_id'], self.server_json['encryptedId'])
-        if 'encryptedIdDisplayValue' in self.server_json:
-            self.assertEqual(serialized_json['encrypted_id_display_value'], self.server_json['encryptedIdDisplayValue'])
-
-        # Check common fields that don't need transformation
-        for field in ['id', 'name', 'uuid']:
-            if field in self.server_json:
-                self.assertEqual(serialized_json[field], self.server_json[field])
-
-        # Check lists length
-        if 'roles' in self.server_json:
-            self.assertEqual(len(serialized_json['roles']), len(self.server_json['roles']))
-        if 'groups' in self.server_json:
-            self.assertEqual(len(serialized_json['groups']), len(self.server_json['groups']))
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("ConductorUser"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_conductor_user_serde(server_json):  #  noqa: PLR0915
+    conductor_user = ConductorUser()
+    conductor_user_dict = server_json
+    if "id" in conductor_user_dict:
+        conductor_user.id = conductor_user_dict["id"]
+    if "name" in conductor_user_dict:
+        conductor_user.name = conductor_user_dict["name"]
+    if "roles" in conductor_user_dict:
+        roles_list = []
+        for _ in conductor_user_dict["roles"]:
+            role = Role()
+            roles_list.append(role)
+        conductor_user.roles = roles_list
+    if "groups" in conductor_user_dict:
+        groups_list = []
+        for group_data in conductor_user_dict["groups"]:
+            group = Group()
+            groups_list.append(group)
+        conductor_user.groups = groups_list
+    if "uuid" in conductor_user_dict:
+        conductor_user.uuid = conductor_user_dict["uuid"]
+    if "applicationUser" in conductor_user_dict:
+        conductor_user.application_user = conductor_user_dict["applicationUser"]
+    if "encryptedId" in conductor_user_dict:
+        conductor_user.encrypted_id = conductor_user_dict["encryptedId"]
+    if "encryptedIdDisplayValue" in conductor_user_dict:
+        conductor_user.encrypted_id_display_value = conductor_user_dict[
+            "encryptedIdDisplayValue"
+        ]
+    expected_id = server_json.get("id", None)
+    assert conductor_user.id == expected_id
+    expected_name = server_json.get("name", None)
+    assert conductor_user.name == expected_name
+    if "roles" in server_json:
+        assert len(conductor_user.roles) == len(server_json["roles"])
+    if "groups" in server_json:
+        assert len(conductor_user.groups) == len(server_json["groups"])
+    expected_uuid = server_json.get("uuid", None)
+    assert conductor_user.uuid == expected_uuid
+    expected_app_user = server_json.get("applicationUser", None)
+    assert conductor_user.application_user == expected_app_user
+    expected_encrypted_id = server_json.get("encryptedId", None)
+    assert conductor_user.encrypted_id == expected_encrypted_id
+    expected_encrypted_id_display = server_json.get("encryptedIdDisplayValue", None)
+    assert conductor_user.encrypted_id_display_value == expected_encrypted_id_display
+    serialized_json = conductor_user.to_dict()
+    if "applicationUser" in server_json:
+        assert serialized_json["application_user"] == server_json["applicationUser"]
+    if "encryptedId" in server_json:
+        assert serialized_json["encrypted_id"] == server_json["encryptedId"]
+    if "encryptedIdDisplayValue" in server_json:
+        assert (
+            serialized_json["encrypted_id_display_value"]
+            == server_json["encryptedIdDisplayValue"]
+        )
+    for field in ["id", "name", "uuid"]:
+        if field in server_json:
+            assert serialized_json[field] == server_json[field]
+    if "roles" in server_json:
+        assert len(serialized_json["roles"]) == len(server_json["roles"])
+    if "groups" in server_json:
+        assert len(serialized_json["groups"]) == len(server_json["groups"])

--- a/tests/serdesertest/test_serdeser_correlation_ids_search_request.py
+++ b/tests/serdesertest/test_serdeser_correlation_ids_search_request.py
@@ -1,58 +1,46 @@
-import unittest
 import json
 
-from conductor.client.http.models.correlation_ids_search_request import CorrelationIdsSearchRequest
+import pytest
+
+from conductor.client.http.models.correlation_ids_search_request import (
+    CorrelationIdsSearchRequest,
+)
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
-class TestCorrelationIdsSearchRequest(unittest.TestCase):
-    """Test case for CorrelationIdsSearchRequest class."""
 
-    def setUp(self):
-        """Set up test fixtures."""
-        # Load the JSON template for CorrelationIdsSearchRequest
-        self.server_json_str = JsonTemplateResolver.get_json_string("CorrelationIdsSearchRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-        # Convert camelCase to snake_case for initialization
-        self.python_format_json = {}
-        for key, value in self.server_json.items():
-            # Use the attribute_map to find the Python property name
-            python_key = next((k for k, v in CorrelationIdsSearchRequest.attribute_map.items() if v == key), key)
-            self.python_format_json[python_key] = value
-
-    def test_serdeser_correlation_ids_search_request(self):
-        """Test serialization and deserialization of CorrelationIdsSearchRequest."""
-        # 1. Server JSON can be correctly deserialized into SDK model object
-        model_obj = CorrelationIdsSearchRequest(**self.python_format_json)
-
-        # 2. All fields are properly populated during deserialization
-        # Check correlation_ids (list[str])
-        self.assertIsNotNone(model_obj.correlation_ids)
-        self.assertIsInstance(model_obj.correlation_ids, list)
-        for item in model_obj.correlation_ids:
-            self.assertIsInstance(item, str)
-
-        # Check workflow_names (list[str])
-        self.assertIsNotNone(model_obj.workflow_names)
-        self.assertIsInstance(model_obj.workflow_names, list)
-        for item in model_obj.workflow_names:
-            self.assertIsInstance(item, str)
-
-        # 3. The SDK model can be serialized back to JSON
-        serialized_dict = model_obj.to_dict()
-
-        # 4. The resulting JSON matches the original
-        # Convert serialized dict keys to camelCase for comparison
-        json_dict = {}
-        for attr, value in serialized_dict.items():
-            if attr in model_obj.attribute_map:
-                json_dict[model_obj.attribute_map[attr]] = value
-            else:
-                json_dict[attr] = value
-
-        # Compare with original JSON
-        self.assertEqual(self.server_json, json_dict)
+@pytest.fixture
+def server_json():
+    return json.loads(
+        JsonTemplateResolver.get_json_string("CorrelationIdsSearchRequest")
+    )
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_serdeser_correlation_ids_search_request(server_json):
+    python_format_json = {}
+    for key, value in server_json.items():
+        python_key = next(
+            (
+                k
+                for k, v in CorrelationIdsSearchRequest.attribute_map.items()
+                if v == key
+            ),
+            key,
+        )
+        python_format_json[python_key] = value
+    model_obj = CorrelationIdsSearchRequest(**python_format_json)
+    assert model_obj.correlation_ids is not None
+    assert isinstance(model_obj.correlation_ids, list)
+    for item in model_obj.correlation_ids:
+        assert isinstance(item, str)
+    assert model_obj.workflow_names is not None
+    assert isinstance(model_obj.workflow_names, list)
+    for item in model_obj.workflow_names:
+        assert isinstance(item, str)
+    serialized_dict = model_obj.to_dict()
+    json_dict = {}
+    for attr, value in serialized_dict.items():
+        if attr in model_obj.attribute_map:
+            json_dict[model_obj.attribute_map[attr]] = value
+        else:
+            json_dict[attr] = value
+    assert server_json == json_dict

--- a/tests/serdesertest/test_serdeser_create_or_update_application_request.py
+++ b/tests/serdesertest/test_serdeser_create_or_update_application_request.py
@@ -1,45 +1,25 @@
-import unittest
 import json
+
+import pytest
 
 from conductor.client.http.models import CreateOrUpdateApplicationRequest
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestCreateOrUpdateApplicationRequest(unittest.TestCase):
-    """Test case for serialization and deserialization of CreateOrUpdateApplicationRequest model."""
-
-    def setUp(self):
-        """Set up test fixtures."""
-        self.server_json_str = JsonTemplateResolver.get_json_string("CreateOrUpdateApplicationRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_deserialize_serialize(self):
-        """Test deserialization from JSON and serialization back to JSON."""
-        # 1. Deserialize server JSON into model object
-        model = CreateOrUpdateApplicationRequest()
-        model_dict = self.server_json
-
-        # Set attributes from JSON
-        if 'name' in model_dict:
-            model.name = model_dict['name']
-
-        # 2. Verify all fields are properly populated
-        expected_name = self.server_json.get('name')
-        self.assertEqual(model.name, expected_name,
-                         f"Field 'name' was not properly deserialized. Expected: {expected_name}, Got: {model.name}")
-
-        # 3. Serialize model back to JSON
-        serialized_dict = model.to_dict()
-
-        # 4. Verify the resulting JSON matches the original
-        # Check field by field to make detailed assertions
-        self.assertEqual(serialized_dict.get('name'), self.server_json.get('name'),
-                         "Field 'name' did not match after serialization")
-
-        # Verify overall dictionary equality
-        self.assertEqual(serialized_dict, self.server_json,
-                         "Serialized JSON doesn't match the original server JSON")
+@pytest.fixture
+def server_json():
+    return json.loads(
+        JsonTemplateResolver.get_json_string("CreateOrUpdateApplicationRequest")
+    )
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_deserialize_serialize(server_json):
+    model = CreateOrUpdateApplicationRequest()
+    model_dict = server_json
+    if "name" in model_dict:
+        model.name = model_dict["name"]
+    expected_name = server_json.get("name")
+    assert model.name == expected_name
+    serialized_dict = model.to_dict()
+    assert serialized_dict.get("name") == server_json.get("name")
+    assert serialized_dict == server_json

--- a/tests/serdesertest/test_serdeser_event_handler.py
+++ b/tests/serdesertest/test_serdeser_event_handler.py
@@ -1,95 +1,59 @@
-import unittest
 import json
-from conductor.client.http.models.event_handler import EventHandler
+
+import pytest
+
 from conductor.client.http.models.action import Action
+from conductor.client.http.models.event_handler import EventHandler
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestEventHandlerSerDe(unittest.TestCase):
-    """Test serialization and deserialization of EventHandler model"""
-
-    def setUp(self):
-        # Load template JSON using resolver
-        self.server_json_str = JsonTemplateResolver.get_json_string("EventHandler")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_deserialize_serialize(self):
-        """Test deserialization and serialization of EventHandler model"""
-        # 1. Deserialize server JSON into SDK model object
-        # Create Action objects first for the actions list
-        actions = []
-        if self.server_json.get('actions'):
-            for action_json in self.server_json.get('actions'):
-                # Convert JSON keys to Python attribute names using the attribute map
-                converted_action = {}
-                for key, value in action_json.items():
-                    # Find the Python attribute name for this JSON key
-                    python_attr = None
-                    for attr, json_key in Action.attribute_map.items():
-                        if json_key == key:
-                            python_attr = attr
-                            break
-
-                    if python_attr:
-                        converted_action[python_attr] = value
-                    else:
-                        # Skip keys not in attribute_map
-                        pass
-
-                action = Action(**converted_action)
-                actions.append(action)
-
-        # Create EventHandler object using constructor
-        model = EventHandler(
-            name=self.server_json.get('name'),
-            event=self.server_json.get('event'),
-            condition=self.server_json.get('condition'),
-            actions=actions,
-            active=self.server_json.get('active'),
-            evaluator_type=self.server_json.get('evaluatorType')
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(model.name, self.server_json.get('name'))
-        self.assertEqual(model.event, self.server_json.get('event'))
-        self.assertEqual(model.condition, self.server_json.get('condition'))
-        self.assertEqual(model.active, self.server_json.get('active'))
-        self.assertEqual(model.evaluator_type, self.server_json.get('evaluatorType'))
-
-        # Verify actions list
-        self.assertIsNotNone(model.actions)
-        self.assertEqual(len(model.actions), len(self.server_json.get('actions', [])))
-
-        # If actions exist in the JSON, verify each action is properly deserialized
-        if self.server_json.get('actions'):
-            for i, action in enumerate(model.actions):
-                self.assertIsInstance(action, Action)
-                # Further verification of Action properties could be done here
-
-        # 3. Serialize the model back to JSON
-        result_json = model.to_dict()
-
-        # 4. Ensure the resulting JSON matches the original
-        # Verify field mapping between camelCase and snake_case
-        self.assertEqual(result_json.get('name'), self.server_json.get('name'))
-        self.assertEqual(result_json.get('event'), self.server_json.get('event'))
-        self.assertEqual(result_json.get('condition'), self.server_json.get('condition'))
-        self.assertEqual(result_json.get('active'), self.server_json.get('active'))
-
-        # The SDK uses evaluator_type internally but the JSON may use evaluatorType
-        # Check how the field is serialized in the result
-        if 'evaluator_type' in result_json:
-            self.assertEqual(result_json.get('evaluator_type'), self.server_json.get('evaluatorType'))
-        elif 'evaluatorType' in result_json:
-            self.assertEqual(result_json.get('evaluatorType'), self.server_json.get('evaluatorType'))
-
-        # Verify complex structures like lists
-        if self.server_json.get('actions'):
-            self.assertEqual(len(result_json.get('actions')), len(self.server_json.get('actions')))
-
-            # Additional validation of actions could be done here
-            # This would depend on how Action.to_dict() handles serialization
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("EventHandler")
+    return json.loads(server_json_str)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_deserialize_serialize(server_json):
+    actions = []
+    if server_json.get("actions"):
+        for action_json in server_json.get("actions"):
+            converted_action = {}
+            for key, value in action_json.items():
+                python_attr = None
+                for attr, json_key in Action.attribute_map.items():
+                    if json_key == key:
+                        python_attr = attr
+                        break
+                if python_attr:
+                    converted_action[python_attr] = value
+            action = Action(**converted_action)
+            actions.append(action)
+    model = EventHandler(
+        name=server_json.get("name"),
+        event=server_json.get("event"),
+        condition=server_json.get("condition"),
+        actions=actions,
+        active=server_json.get("active"),
+        evaluator_type=server_json.get("evaluatorType"),
+    )
+    assert model.name == server_json.get("name")
+    assert model.event == server_json.get("event")
+    assert model.condition == server_json.get("condition")
+    assert model.active == server_json.get("active")
+    assert model.evaluator_type == server_json.get("evaluatorType")
+    assert model.actions is not None
+    assert len(model.actions) == len(server_json.get("actions", []))
+    if server_json.get("actions"):
+        for action in model.actions:
+            assert isinstance(action, Action)
+    result_json = model.to_dict()
+    assert result_json.get("name") == server_json.get("name")
+    assert result_json.get("event") == server_json.get("event")
+    assert result_json.get("condition") == server_json.get("condition")
+    assert result_json.get("active") == server_json.get("active")
+    if "evaluator_type" in result_json:
+        assert result_json.get("evaluator_type") == server_json.get("evaluatorType")
+    elif "evaluatorType" in result_json:
+        assert result_json.get("evaluatorType") == server_json.get("evaluatorType")
+    if server_json.get("actions"):
+        assert len(result_json.get("actions")) == len(server_json.get("actions"))

--- a/tests/serdesertest/test_serdeser_external_storage_location.py
+++ b/tests/serdesertest/test_serdeser_external_storage_location.py
@@ -1,36 +1,25 @@
 import json
-import unittest
-from conductor.client.http.models.external_storage_location import ExternalStorageLocation
+
+import pytest
+
+from conductor.client.http.models.external_storage_location import (
+    ExternalStorageLocation,
+)
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestExternalStorageLocationSerDe(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("ExternalStorageLocation")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_external_storage_location_serde(self):
-        # 1. Deserialize JSON to model object
-        model = ExternalStorageLocation(
-            uri=self.server_json.get('uri'),
-            path=self.server_json.get('path')
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get('uri'), model.uri)
-        self.assertEqual(self.server_json.get('path'), model.path)
-
-        # 3. Serialize model back to dict
-        model_dict = model.to_dict()
-
-        # 4. Verify the serialized model matches the original JSON
-        self.assertEqual(self.server_json.get('uri'), model_dict.get('uri'))
-        self.assertEqual(self.server_json.get('path'), model_dict.get('path'))
-
-        # Additional check for dictionary equivalence
-        self.assertEqual(set(self.server_json.keys()), set(model_dict.keys()))
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("ExternalStorageLocation"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_external_storage_location_serde(server_json):
+    model = ExternalStorageLocation(
+        uri=server_json.get("uri"), path=server_json.get("path")
+    )
+    assert server_json.get("uri") == model.uri
+    assert server_json.get("path") == model.path
+    model_dict = model.to_dict()
+    assert server_json.get("uri") == model_dict.get("uri")
+    assert server_json.get("path") == model_dict.get("path")
+    assert set(server_json.keys()) == set(model_dict.keys())

--- a/tests/serdesertest/test_serdeser_generate_token_request.py
+++ b/tests/serdesertest/test_serdeser_generate_token_request.py
@@ -1,50 +1,31 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.generate_token_request import GenerateTokenRequest
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestGenerateTokenRequestSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template using JsonTemplateResolver
-        self.server_json_str = JsonTemplateResolver.get_json_string("GenerateTokenRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_generate_token_request_ser_des(self):
-        """Test serialization and deserialization of GenerateTokenRequest"""
-
-        # 1. Deserialize JSON into model object
-        model_obj = GenerateTokenRequest(
-            key_id=self.server_json['keyId'],
-            key_secret=self.server_json['keySecret']
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(model_obj.key_id, self.server_json['keyId'])
-        self.assertEqual(model_obj.key_secret, self.server_json['keySecret'])
-
-        # 3. Serialize model back to JSON
-        model_json = model_obj.to_dict()
-
-        # Convert snake_case back to camelCase for comparison
-        serialized_json = {
-            'keyId': model_json['key_id'],
-            'keySecret': model_json['key_secret']
-        }
-
-        # 4. Verify the resulting JSON matches the original
-        self.assertEqual(serialized_json['keyId'], self.server_json['keyId'])
-        self.assertEqual(serialized_json['keySecret'], self.server_json['keySecret'])
-
-        # Verify the object equality methods
-        duplicate_obj = GenerateTokenRequest(
-            key_id=self.server_json['keyId'],
-            key_secret=self.server_json['keySecret']
-        )
-
-        self.assertEqual(model_obj, duplicate_obj)
-        self.assertNotEqual(model_obj, GenerateTokenRequest(key_id="different", key_secret="values"))
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("GenerateTokenRequest"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_generate_token_request_ser_des(server_json):
+    model_obj = GenerateTokenRequest(
+        key_id=server_json["keyId"], key_secret=server_json["keySecret"]
+    )
+    assert model_obj.key_id == server_json["keyId"]
+    assert model_obj.key_secret == server_json["keySecret"]
+    model_json = model_obj.to_dict()
+    serialized_json = {
+        "keyId": model_json["key_id"],
+        "keySecret": model_json["key_secret"],
+    }
+    assert serialized_json["keyId"] == server_json["keyId"]
+    assert serialized_json["keySecret"] == server_json["keySecret"]
+    duplicate_obj = GenerateTokenRequest(
+        key_id=server_json["keyId"], key_secret=server_json["keySecret"]
+    )
+    assert model_obj == duplicate_obj
+    assert model_obj != GenerateTokenRequest(key_id="different", key_secret="values")

--- a/tests/serdesertest/test_serdeser_group.py
+++ b/tests/serdesertest/test_serdeser_group.py
@@ -1,77 +1,63 @@
-import unittest
+import json
+
+import pytest
+
 from conductor.client.http.models.group import Group
 from conductor.client.http.models.role import Role
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
-import json
 
 
-class TestGroupSerDeSer(unittest.TestCase):
-    def setUp(self):
-        # Load JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("Group")
-        self.server_json = json.loads(self.server_json_str)
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("Group"))
 
-    def test_group_serde(self):
-        # 1. Deserialize server JSON into SDK model
-        group = Group(
-            id=self.server_json.get("id"),
-            description=self.server_json.get("description"),
-            roles=[Role(**role) for role in self.server_json.get("roles", [])],
-            default_access=self.server_json.get("defaultAccess")
-        )
 
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get("id"), group.id)
-        self.assertEqual(self.server_json.get("description"), group.description)
-
-        # Verify roles list
-        if self.server_json.get("roles"):
-            self.assertIsNotNone(group.roles)
-            self.assertEqual(len(self.server_json.get("roles")), len(group.roles))
-            for i, role in enumerate(group.roles):
-                self.assertIsInstance(role, Role)
-                # Check key properties of role objects
-                self.assertEqual(self.server_json.get("roles")[i].get("name"), role.name)
-
-        # Verify default_access map
-        if self.server_json.get("defaultAccess"):
-            self.assertIsNotNone(group.default_access)
-            for key in self.server_json.get("defaultAccess").keys():
-                self.assertIn(key, group.default_access)
-                self.assertEqual(self.server_json.get("defaultAccess")[key], group.default_access[key])
-
-        # 3. Serialize model back to dict
-        result_dict = group.to_dict()
-
-        # Transform dict keys from snake_case to camelCase for comparison
-        camel_case_dict = {}
-        for key, value in result_dict.items():
-            json_key = Group.attribute_map.get(key, key)
-            camel_case_dict[json_key] = value
-
-        # 4. Verify the resulting dict matches the original
-        for key in self.server_json.keys():
-            if key == "roles":
-                # For roles list, we need to compare their dict representations
-                if self.server_json.get("roles"):
-                    self.assertEqual(len(self.server_json.get("roles")), len(camel_case_dict.get("roles", [])))
-                    for i, role_dict in enumerate(camel_case_dict.get("roles", [])):
-                        for role_key in self.server_json.get("roles")[i].keys():
-                            self.assertEqual(
-                                self.server_json.get("roles")[i].get(role_key),
-                                role_dict.get(
-                                    Role.attribute_map.get(role_key.replace("camelCase", "snake_case"), role_key))
+def test_group_serde(server_json):
+    group = Group(
+        id=server_json.get("id"),
+        description=server_json.get("description"),
+        roles=[Role(**role) for role in server_json.get("roles", [])],
+        default_access=server_json.get("defaultAccess"),
+    )
+    assert server_json.get("id") == group.id
+    assert server_json.get("description") == group.description
+    if server_json.get("roles"):
+        assert group.roles is not None
+        assert len(server_json.get("roles")) == len(group.roles)
+        for i, role in enumerate(group.roles):
+            assert isinstance(role, Role)
+            assert server_json.get("roles")[i].get("name") == role.name
+    if server_json.get("defaultAccess"):
+        assert group.default_access is not None
+        for key in server_json.get("defaultAccess").keys():
+            assert key in group.default_access
+            assert server_json.get("defaultAccess")[key] == group.default_access[key]
+    result_dict = group.to_dict()
+    camel_case_dict = {}
+    for key, value in result_dict.items():
+        json_key = Group.attribute_map.get(key, key)
+        camel_case_dict[json_key] = value
+    for key in server_json.keys():
+        if key == "roles":
+            if server_json.get("roles"):
+                assert len(server_json.get("roles")) == len(
+                    camel_case_dict.get("roles", [])
+                )
+                for i, role_dict in enumerate(camel_case_dict.get("roles", [])):
+                    for role_key in server_json.get("roles")[i].keys():
+                        assert server_json.get("roles")[i].get(
+                            role_key
+                        ) == role_dict.get(
+                            Role.attribute_map.get(
+                                role_key.replace("camelCase", "snake_case"), role_key
                             )
-            elif key == "defaultAccess":
-                # For maps, compare each key-value pair
-                if self.server_json.get("defaultAccess"):
-                    for map_key, map_value in self.server_json.get("defaultAccess").items():
-                        self.assertIn(map_key, camel_case_dict.get("defaultAccess", {}))
-                        self.assertEqual(map_value, camel_case_dict.get("defaultAccess", {}).get(map_key))
-            else:
-                # For simple fields, direct comparison
-                self.assertEqual(self.server_json.get(key), camel_case_dict.get(key))
-
-
-if __name__ == "__main__":
-    unittest.main()
+                        )
+        elif key == "defaultAccess":
+            if server_json.get("defaultAccess"):
+                for map_key, map_value in server_json.get("defaultAccess").items():
+                    assert map_key in camel_case_dict.get("defaultAccess", {})
+                    assert map_value == camel_case_dict.get("defaultAccess", {}).get(
+                        map_key
+                    )
+        else:
+            assert server_json.get(key) == camel_case_dict.get(key)

--- a/tests/serdesertest/test_serdeser_integration.py
+++ b/tests/serdesertest/test_serdeser_integration.py
@@ -1,65 +1,51 @@
 import json
-import unittest
+
+import pytest
+
 from conductor.client.http.models.integration import Integration
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class IntegrationSerdeserTest(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("Integration")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_integration_serdeser(self):
-        # 1. Deserialize JSON into model object
-        integration = Integration(
-            category=self.server_json.get("category"),
-            configuration=self.server_json.get("configuration"),
-            created_by=self.server_json.get("createdBy"),
-            created_on=self.server_json.get("createdOn"),
-            description=self.server_json.get("description"),
-            enabled=self.server_json.get("enabled"),
-            models_count=self.server_json.get("modelsCount"),
-            name=self.server_json.get("name"),
-            tags=self.server_json.get("tags"),
-            type=self.server_json.get("type"),
-            updated_by=self.server_json.get("updatedBy"),
-            updated_on=self.server_json.get("updatedOn"),
-            apis=self.server_json.get("apis")
-        )
-
-        # 2. Verify all fields are correctly populated
-        self.assertEqual(self.server_json.get("category"), integration.category)
-        self.assertEqual(self.server_json.get("configuration"), integration.configuration)
-        self.assertEqual(self.server_json.get("createdBy"), integration.created_by)
-        self.assertEqual(self.server_json.get("createdOn"), integration.created_on)
-        self.assertEqual(self.server_json.get("description"), integration.description)
-        self.assertEqual(self.server_json.get("enabled"), integration.enabled)
-        self.assertEqual(self.server_json.get("modelsCount"), integration.models_count)
-        self.assertEqual(self.server_json.get("name"), integration.name)
-        self.assertEqual(self.server_json.get("tags"), integration.tags)
-        self.assertEqual(self.server_json.get("type"), integration.type)
-        self.assertEqual(self.server_json.get("updatedBy"), integration.updated_by)
-        self.assertEqual(self.server_json.get("updatedOn"), integration.updated_on)
-        self.assertEqual(self.server_json.get("apis"), integration.apis)
-
-        # Special check for enum values
-        if integration.category is not None:
-            self.assertIn(integration.category, ["API", "AI_MODEL", "VECTOR_DB", "RELATIONAL_DB"])
-
-        # 3. Serialize model back to dict
-        serialized_dict = integration.to_dict()
-
-        # 4. Transform Python's snake_case back to camelCase for comparison
-        transformed_dict = {}
-        for snake_key, value in serialized_dict.items():
-            camel_key = integration.attribute_map.get(snake_key, snake_key)
-            transformed_dict[camel_key] = value
-
-        # Compare original JSON with serialized and transformed dict
-        for key, value in self.server_json.items():
-            self.assertEqual(value, transformed_dict.get(key),
-                             f"Value mismatch for key {key}: Original={value}, Serialized={transformed_dict.get(key)}")
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("Integration"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_integration_serdeser(server_json):
+    integration = Integration(
+        category=server_json.get("category"),
+        configuration=server_json.get("configuration"),
+        created_by=server_json.get("createdBy"),
+        created_on=server_json.get("createdOn"),
+        description=server_json.get("description"),
+        enabled=server_json.get("enabled"),
+        models_count=server_json.get("modelsCount"),
+        name=server_json.get("name"),
+        tags=server_json.get("tags"),
+        type=server_json.get("type"),
+        updated_by=server_json.get("updatedBy"),
+        updated_on=server_json.get("updatedOn"),
+        apis=server_json.get("apis"),
+    )
+    assert server_json.get("category") == integration.category
+    assert server_json.get("configuration") == integration.configuration
+    assert server_json.get("createdBy") == integration.created_by
+    assert server_json.get("createdOn") == integration.created_on
+    assert server_json.get("description") == integration.description
+    assert server_json.get("enabled") == integration.enabled
+    assert server_json.get("modelsCount") == integration.models_count
+    assert server_json.get("name") == integration.name
+    assert server_json.get("tags") == integration.tags
+    assert server_json.get("type") == integration.type
+    assert server_json.get("updatedBy") == integration.updated_by
+    assert server_json.get("updatedOn") == integration.updated_on
+    assert server_json.get("apis") == integration.apis
+    if integration.category is not None:
+        assert integration.category in ["API", "AI_MODEL", "VECTOR_DB", "RELATIONAL_DB"]
+    serialized_dict = integration.to_dict()
+    transformed_dict = {}
+    for snake_key, value in serialized_dict.items():
+        camel_key = integration.attribute_map.get(snake_key, snake_key)
+        transformed_dict[camel_key] = value
+    for key, value in server_json.items():
+        assert value == transformed_dict.get(key)

--- a/tests/serdesertest/test_serdeser_integration_api.py
+++ b/tests/serdesertest/test_serdeser_integration_api.py
@@ -1,91 +1,66 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.integration_api import IntegrationApi
 from conductor.client.http.models.tag_object import TagObject
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class IntegrationApiSerializationTest(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("IntegrationApi")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_integration_api_serialization_deserialization(self):
-        # 1. Deserialize JSON to IntegrationApi object
-        integration_api = IntegrationApi(
-            api=self.server_json.get("api"),
-            configuration=self.server_json.get("configuration"),
-            created_by=self.server_json.get("createdBy"),
-            created_on=self.server_json.get("createdOn"),
-            description=self.server_json.get("description"),
-            enabled=self.server_json.get("enabled"),
-            integration_name=self.server_json.get("integrationName"),
-            tags=[TagObject(
-                key=tag.get("key"),
-                value=tag.get("value")
-            ) for tag in self.server_json.get("tags", [])]
-            if self.server_json.get("tags") else None,
-            updated_by=self.server_json.get("updatedBy"),
-            updated_on=self.server_json.get("updatedOn")
-        )
-
-        # 2. Verify all fields are correctly populated
-        # Simple fields
-        self.assertEqual(self.server_json.get("api"), integration_api.api)
-        self.assertEqual(self.server_json.get("description"), integration_api.description)
-        self.assertEqual(self.server_json.get("enabled"), integration_api.enabled)
-        self.assertEqual(self.server_json.get("integrationName"), integration_api.integration_name)
-
-        # Date/time fields with camelCase to snake_case transformation
-        self.assertEqual(self.server_json.get("createdBy"), integration_api.created_by)
-        self.assertEqual(self.server_json.get("createdOn"), integration_api.created_on)
-        self.assertEqual(self.server_json.get("updatedBy"), integration_api.updated_by)
-        self.assertEqual(self.server_json.get("updatedOn"), integration_api.updated_on)
-
-        # Complex data - configuration (dictionary)
-        self.assertEqual(self.server_json.get("configuration"), integration_api.configuration)
-
-        # Complex data - tags (list of TagObject)
-        if self.server_json.get("tags"):
-            self.assertEqual(len(self.server_json.get("tags")), len(integration_api.tags))
-            for i, tag in enumerate(integration_api.tags):
-                self.assertIsInstance(tag, TagObject)
-                # Verify key fields of TagObject
-                self.assertEqual(self.server_json.get("tags")[i].get("key"), tag.key)
-                self.assertEqual(self.server_json.get("tags")[i].get("value"), tag.value)
-
-        # 3. Serialize back to JSON
-        serialized_json = integration_api.to_dict()
-
-        # 4. Verify the serialized JSON matches the original, field by field
-        # (instead of direct dictionary comparison)
-
-        # Check simple fields
-        for field in ["api", "description", "enabled"]:
-            json_field = field
-            if field in IntegrationApi.attribute_map:
-                json_field = IntegrationApi.attribute_map[field]
-            self.assertEqual(self.server_json.get(json_field), serialized_json.get(field),
-                             f"Field {field} does not match after serialization")
-
-        # Check fields with camelCase to snake_case transformation
-        self.assertEqual(self.server_json.get("createdBy"), serialized_json.get("created_by"))
-        self.assertEqual(self.server_json.get("createdOn"), serialized_json.get("created_on"))
-        self.assertEqual(self.server_json.get("updatedBy"), serialized_json.get("updated_by"))
-        self.assertEqual(self.server_json.get("updatedOn"), serialized_json.get("updated_on"))
-        self.assertEqual(self.server_json.get("integrationName"), serialized_json.get("integration_name"))
-
-        # Check configuration
-        self.assertEqual(self.server_json.get("configuration"), serialized_json.get("configuration"))
-
-        # Check tags manually field by field
-        if self.server_json.get("tags"):
-            for i, original_tag in enumerate(self.server_json.get("tags")):
-                serialized_tag = serialized_json.get("tags")[i]
-                self.assertEqual(original_tag.get("key"), serialized_tag.get("key"))
-                self.assertEqual(original_tag.get("value"), serialized_tag.get("value"))
-                # Now we're just ignoring the 'type' field that's added during serialization
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("IntegrationApi"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_integration_api_serialization_deserialization(server_json):
+    integration_api = IntegrationApi(
+        api=server_json.get("api"),
+        configuration=server_json.get("configuration"),
+        created_by=server_json.get("createdBy"),
+        created_on=server_json.get("createdOn"),
+        description=server_json.get("description"),
+        enabled=server_json.get("enabled"),
+        integration_name=server_json.get("integrationName"),
+        tags=(
+            [
+                TagObject(key=tag.get("key"), value=tag.get("value"))
+                for tag in server_json.get("tags", [])
+            ]
+            if server_json.get("tags")
+            else None
+        ),
+        updated_by=server_json.get("updatedBy"),
+        updated_on=server_json.get("updatedOn"),
+    )
+    assert server_json.get("api") == integration_api.api
+    assert server_json.get("description") == integration_api.description
+    assert server_json.get("enabled") == integration_api.enabled
+    assert server_json.get("integrationName") == integration_api.integration_name
+    assert server_json.get("createdBy") == integration_api.created_by
+    assert server_json.get("createdOn") == integration_api.created_on
+    assert server_json.get("updatedBy") == integration_api.updated_by
+    assert server_json.get("updatedOn") == integration_api.updated_on
+    assert server_json.get("configuration") == integration_api.configuration
+    if server_json.get("tags"):
+        assert len(server_json.get("tags")) == len(integration_api.tags)
+        for i, tag in enumerate(integration_api.tags):
+            assert isinstance(tag, TagObject)
+            assert server_json.get("tags")[i].get("key") == tag.key
+            assert server_json.get("tags")[i].get("value") == tag.value
+    serialized_json = integration_api.to_dict()
+    for field in ["api", "description", "enabled"]:
+        json_field = field
+        if field in IntegrationApi.attribute_map:
+            json_field = IntegrationApi.attribute_map[field]
+        assert server_json.get(json_field) == serialized_json.get(field)
+    assert server_json.get("createdBy") == serialized_json.get("created_by")
+    assert server_json.get("createdOn") == serialized_json.get("created_on")
+    assert server_json.get("updatedBy") == serialized_json.get("updated_by")
+    assert server_json.get("updatedOn") == serialized_json.get("updated_on")
+    assert server_json.get("integrationName") == serialized_json.get("integration_name")
+    assert server_json.get("configuration") == serialized_json.get("configuration")
+    if server_json.get("tags"):
+        for i, original_tag in enumerate(server_json.get("tags")):
+            serialized_tag = serialized_json.get("tags")[i]
+            assert original_tag.get("key") == serialized_tag.get("key")
+            assert original_tag.get("value") == serialized_tag.get("value")

--- a/tests/serdesertest/test_serdeser_integration_def.py
+++ b/tests/serdesertest/test_serdeser_integration_def.py
@@ -1,63 +1,49 @@
-import unittest
-from conductor.client.http.models.integration_def import IntegrationDef
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 import json
 
+import pytest
 
-class TestIntegrationDefSerialization(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("IntegrationDef")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_serialization_deserialization(self):
-        # 1. Test deserialization from server JSON to SDK model
-        integration_def = IntegrationDef(
-            category=self.server_json['category'],
-            category_label=self.server_json['categoryLabel'],
-            configuration=self.server_json['configuration'],
-            description=self.server_json['description'],
-            enabled=self.server_json['enabled'],
-            icon_name=self.server_json['iconName'],
-            name=self.server_json['name'],
-            tags=self.server_json['tags'],
-            type=self.server_json['type']
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(integration_def.category, self.server_json['category'])
-        self.assertEqual(integration_def.category_label, self.server_json['categoryLabel'])
-        self.assertEqual(integration_def.configuration, self.server_json['configuration'])
-        self.assertEqual(integration_def.description, self.server_json['description'])
-        self.assertEqual(integration_def.enabled, self.server_json['enabled'])
-        self.assertEqual(integration_def.icon_name, self.server_json['iconName'])
-        self.assertEqual(integration_def.name, self.server_json['name'])
-        self.assertEqual(integration_def.tags, self.server_json['tags'])
-        self.assertEqual(integration_def.type, self.server_json['type'])
-
-        # Check that enum values are valid for category
-        self.assertIn(integration_def.category, ["API", "AI_MODEL", "VECTOR_DB", "RELATIONAL_DB"])
-
-        # Check that complex structures are properly populated
-        if integration_def.tags:
-            self.assertIsInstance(integration_def.tags, list)
-
-        if integration_def.configuration:
-            self.assertIsInstance(integration_def.configuration, list)
-
-        # 3. Test serialization back to JSON
-        serialized_json = integration_def.to_dict()
-
-        # 4. Verify the resulting JSON matches the original
-        self.assertEqual(serialized_json['category'], self.server_json['category'])
-        self.assertEqual(serialized_json['category_label'], self.server_json['categoryLabel'])
-        self.assertEqual(serialized_json['configuration'], self.server_json['configuration'])
-        self.assertEqual(serialized_json['description'], self.server_json['description'])
-        self.assertEqual(serialized_json['enabled'], self.server_json['enabled'])
-        self.assertEqual(serialized_json['icon_name'], self.server_json['iconName'])
-        self.assertEqual(serialized_json['name'], self.server_json['name'])
-        self.assertEqual(serialized_json['tags'], self.server_json['tags'])
-        self.assertEqual(serialized_json['type'], self.server_json['type'])
+from conductor.client.http.models.integration_def import IntegrationDef
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("IntegrationDef"))
+
+
+def test_serialization_deserialization(server_json):
+    integration_def = IntegrationDef(
+        category=server_json["category"],
+        category_label=server_json["categoryLabel"],
+        configuration=server_json["configuration"],
+        description=server_json["description"],
+        enabled=server_json["enabled"],
+        icon_name=server_json["iconName"],
+        name=server_json["name"],
+        tags=server_json["tags"],
+        type=server_json["type"],
+    )
+    assert integration_def.category == server_json["category"]
+    assert integration_def.category_label == server_json["categoryLabel"]
+    assert integration_def.configuration == server_json["configuration"]
+    assert integration_def.description == server_json["description"]
+    assert integration_def.enabled == server_json["enabled"]
+    assert integration_def.icon_name == server_json["iconName"]
+    assert integration_def.name == server_json["name"]
+    assert integration_def.tags == server_json["tags"]
+    assert integration_def.type == server_json["type"]
+    assert integration_def.category in ["API", "AI_MODEL", "VECTOR_DB", "RELATIONAL_DB"]
+    if integration_def.tags:
+        assert isinstance(integration_def.tags, list)
+    if integration_def.configuration:
+        assert isinstance(integration_def.configuration, list)
+    serialized_json = integration_def.to_dict()
+    assert serialized_json["category"] == server_json["category"]
+    assert serialized_json["category_label"] == server_json["categoryLabel"]
+    assert serialized_json["configuration"] == server_json["configuration"]
+    assert serialized_json["description"] == server_json["description"]
+    assert serialized_json["enabled"] == server_json["enabled"]
+    assert serialized_json["icon_name"] == server_json["iconName"]
+    assert serialized_json["name"] == server_json["name"]
+    assert serialized_json["tags"] == server_json["tags"]
+    assert serialized_json["type"] == server_json["type"]

--- a/tests/serdesertest/test_serdeser_integration_update.py
+++ b/tests/serdesertest/test_serdeser_integration_update.py
@@ -1,53 +1,40 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.integration_update import IntegrationUpdate
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestIntegrationUpdateSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("IntegrationUpdate")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_integration_update_serdes(self):
-        # 1. Deserialize JSON into SDK model object
-        integration_update = IntegrationUpdate(
-            category=self.server_json.get("category"),
-            configuration=self.server_json.get("configuration"),
-            description=self.server_json.get("description"),
-            enabled=self.server_json.get("enabled"),
-            type=self.server_json.get("type")
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get("category"), integration_update.category)
-        self.assertEqual(self.server_json.get("configuration"), integration_update.configuration)
-        self.assertEqual(self.server_json.get("description"), integration_update.description)
-        self.assertEqual(self.server_json.get("enabled"), integration_update.enabled)
-        self.assertEqual(self.server_json.get("type"), integration_update.type)
-
-        # Specifically verify enum value for category is valid
-        self.assertIn(integration_update.category, ["API", "AI_MODEL", "VECTOR_DB", "RELATIONAL_DB"])
-
-        # 3. Serialize SDK model back to JSON
-        model_dict = integration_update.to_dict()
-
-        # 4. Verify the resulting JSON matches the original
-        self.assertEqual(self.server_json.get("category"), model_dict.get("category"))
-        self.assertEqual(self.server_json.get("configuration"), model_dict.get("configuration"))
-        self.assertEqual(self.server_json.get("description"), model_dict.get("description"))
-        self.assertEqual(self.server_json.get("enabled"), model_dict.get("enabled"))
-        self.assertEqual(self.server_json.get("type"), model_dict.get("type"))
-
-        # Extra validation for complex fields
-        if integration_update.configuration:
-            # If configuration is a map, verify its structure is preserved
-            self.assertEqual(
-                self.server_json.get("configuration"),
-                model_dict.get("configuration")
-            )
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("IntegrationUpdate"))
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_integration_update_serdes(server_json):
+    integration_update = IntegrationUpdate(
+        category=server_json.get("category"),
+        configuration=server_json.get("configuration"),
+        description=server_json.get("description"),
+        enabled=server_json.get("enabled"),
+        type=server_json.get("type"),
+    )
+    assert server_json.get("category") == integration_update.category
+    assert server_json.get("configuration") == integration_update.configuration
+    assert server_json.get("description") == integration_update.description
+    assert server_json.get("enabled") == integration_update.enabled
+    assert server_json.get("type") == integration_update.type
+    assert integration_update.category in [
+        "API",
+        "AI_MODEL",
+        "VECTOR_DB",
+        "RELATIONAL_DB",
+    ]
+    model_dict = integration_update.to_dict()
+    assert server_json.get("category") == model_dict.get("category")
+    assert server_json.get("configuration") == model_dict.get("configuration")
+    assert server_json.get("description") == model_dict.get("description")
+    assert server_json.get("enabled") == model_dict.get("enabled")
+    assert server_json.get("type") == model_dict.get("type")
+    if integration_update.configuration:
+        assert server_json.get("configuration") == model_dict.get("configuration")

--- a/tests/serdesertest/test_serdeser_permission.py
+++ b/tests/serdesertest/test_serdeser_permission.py
@@ -1,38 +1,22 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.permission import Permission
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestPermissionSerialization(unittest.TestCase):
-    def setUp(self):
-        # Load template JSON using the resolver utility
-        self.server_json_str = JsonTemplateResolver.get_json_string("Permission")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_permission_serde(self):
-        # 1. Server JSON can be correctly deserialized into SDK model object
-        permission_obj = Permission(name=self.server_json.get("name"))
-
-        # 2. All fields are properly populated during deserialization
-        self.assertEqual(permission_obj.name, self.server_json.get("name"))
-
-        # 3. The SDK model can be serialized back to JSON
-        serialized_json = permission_obj.to_dict()
-
-        # 4. The resulting JSON matches the original, ensuring no data is lost
-        # Handle potential camelCase to snake_case transformations
-        self.assertEqual(serialized_json.get("name"), self.server_json.get("name"))
-
-        # Additional verification to ensure all fields in original JSON are in serialized JSON
-        for key in self.server_json:
-            # Convert camelCase to snake_case if needed
-            python_key = key
-            self.assertIn(python_key, serialized_json)
-
-        # Verify no extra fields were added during serialization
-        self.assertEqual(len(serialized_json), len(self.server_json))
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("Permission"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_permission_serde(server_json):
+    permission_obj = Permission(name=server_json.get("name"))
+    assert permission_obj.name == server_json.get("name")
+    serialized_json = permission_obj.to_dict()
+    assert serialized_json.get("name") == server_json.get("name")
+    for key in server_json:
+        python_key = key
+        assert python_key in serialized_json
+    assert len(serialized_json) == len(server_json)

--- a/tests/serdesertest/test_serdeser_poll_data.py
+++ b/tests/serdesertest/test_serdeser_poll_data.py
@@ -1,51 +1,49 @@
 import json
-import unittest
+
+import pytest
+
 from conductor.client.http.models.poll_data import PollData
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestPollDataSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load JSON template using the utility
-        self.server_json_str = JsonTemplateResolver.get_json_string("PollData")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_poll_data_serdes(self):
-        # 1. Test deserialization from JSON to PollData object
-        poll_data = PollData(
-            queue_name=self.server_json.get("queueName"),
-            domain=self.server_json.get("domain"),
-            worker_id=self.server_json.get("workerId"),
-            last_poll_time=self.server_json.get("lastPollTime")
-        )
-
-        # 2. Verify all fields are correctly populated
-        self.assertEqual(poll_data.queue_name, self.server_json.get("queueName"))
-        self.assertEqual(poll_data.domain, self.server_json.get("domain"))
-        self.assertEqual(poll_data.worker_id, self.server_json.get("workerId"))
-        self.assertEqual(poll_data.last_poll_time, self.server_json.get("lastPollTime"))
-
-        # 3. Test serialization back to JSON
-        serialized_json = poll_data.to_dict()
-
-        # Convert to server JSON format (camelCase)
-        result_json = {
-            "queueName": serialized_json.get("queue_name"),
-            "domain": serialized_json.get("domain"),
-            "workerId": serialized_json.get("worker_id"),
-            "lastPollTime": serialized_json.get("last_poll_time")
-        }
-
-        # 4. Verify resulting JSON matches the original
-        self.assertEqual(result_json.get("queueName"), self.server_json.get("queueName"))
-        self.assertEqual(result_json.get("domain"), self.server_json.get("domain"))
-        self.assertEqual(result_json.get("workerId"), self.server_json.get("workerId"))
-        self.assertEqual(result_json.get("lastPollTime"), self.server_json.get("lastPollTime"))
-
-        # Additional verifications
-        # Ensure no data loss by comparing keys
-        self.assertEqual(set(result_json.keys()), set(self.server_json.keys()))
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("PollData")
+    return json.loads(server_json_str)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_poll_data_serdes(server_json):
+    # 1. Test deserialization from JSON to PollData object
+    poll_data = PollData(
+        queue_name=server_json.get("queueName"),
+        domain=server_json.get("domain"),
+        worker_id=server_json.get("workerId"),
+        last_poll_time=server_json.get("lastPollTime"),
+    )
+
+    # 2. Verify all fields are correctly populated
+    assert poll_data.queue_name == server_json.get("queueName")
+    assert poll_data.domain == server_json.get("domain")
+    assert poll_data.worker_id == server_json.get("workerId")
+    assert poll_data.last_poll_time == server_json.get("lastPollTime")
+
+    # 3. Test serialization back to JSON
+    serialized_json = poll_data.to_dict()
+
+    # Convert to server JSON format (camelCase)
+    result_json = {
+        "queueName": serialized_json.get("queue_name"),
+        "domain": serialized_json.get("domain"),
+        "workerId": serialized_json.get("worker_id"),
+        "lastPollTime": serialized_json.get("last_poll_time"),
+    }
+
+    # 4. Verify resulting JSON matches the original
+    assert result_json.get("queueName") == server_json.get("queueName")
+    assert result_json.get("domain") == server_json.get("domain")
+    assert result_json.get("workerId") == server_json.get("workerId")
+    assert result_json.get("lastPollTime") == server_json.get("lastPollTime")
+
+    # Additional verifications
+    # Ensure no data loss by comparing keys
+    assert set(result_json.keys()) == set(server_json.keys())

--- a/tests/serdesertest/test_serdeser_prompt_test_request.py
+++ b/tests/serdesertest/test_serdeser_prompt_test_request.py
@@ -1,63 +1,38 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.prompt_test_request import PromptTemplateTestRequest
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestPromptTemplateTestRequestSerDes(unittest.TestCase):
-    """Test case for serialization and deserialization of PromptTemplateTestRequest."""
-
-    def setUp(self):
-        """Set up test fixtures, if any."""
-        self.server_json_str = JsonTemplateResolver.get_json_string("PromptTemplateTestRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_prompt_template_test_request_serde(self):
-        """Test PromptTemplateTestRequest serialization/deserialization."""
-        # 1. Deserialize JSON to model object
-        model_obj = PromptTemplateTestRequest(
-            llm_provider=self.server_json.get('llmProvider'),
-            model=self.server_json.get('model'),
-            prompt=self.server_json.get('prompt'),
-            prompt_variables=self.server_json.get('promptVariables'),
-            stop_words=self.server_json.get('stopWords'),
-            temperature=self.server_json.get('temperature'),
-            top_p=self.server_json.get('topP')
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get('llmProvider'), model_obj.llm_provider)
-        self.assertEqual(self.server_json.get('model'), model_obj.model)
-        self.assertEqual(self.server_json.get('prompt'), model_obj.prompt)
-
-        # Check complex data structures
-        self.assertEqual(self.server_json.get('promptVariables'), model_obj.prompt_variables)
-        self.assertEqual(self.server_json.get('stopWords'), model_obj.stop_words)
-
-        # Check numeric values
-        self.assertEqual(self.server_json.get('temperature'), model_obj.temperature)
-        self.assertEqual(self.server_json.get('topP'), model_obj.top_p)
-
-        # 3. Serialize model back to JSON
-        model_json = model_obj.to_dict()
-
-        # Convert snake_case keys back to camelCase for comparison
-        converted_model_json = {}
-        for key, value in model_json.items():
-            # Use the attribute_map to convert back to camelCase
-            camel_key = model_obj.attribute_map.get(key, key)
-            converted_model_json[camel_key] = value
-
-        # 4. Verify that the resulting JSON matches the original
-        for key, value in self.server_json.items():
-            self.assertIn(key, converted_model_json)
-            if isinstance(value, dict):
-                self.assertEqual(value, converted_model_json[key])
-            elif isinstance(value, list):
-                self.assertEqual(value, converted_model_json[key])
-            else:
-                self.assertEqual(value, converted_model_json[key])
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("PromptTemplateTestRequest"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_prompt_template_test_request_serde(server_json):
+    model_obj = PromptTemplateTestRequest(
+        llm_provider=server_json.get("llmProvider"),
+        model=server_json.get("model"),
+        prompt=server_json.get("prompt"),
+        prompt_variables=server_json.get("promptVariables"),
+        stop_words=server_json.get("stopWords"),
+        temperature=server_json.get("temperature"),
+        top_p=server_json.get("topP"),
+    )
+    assert server_json.get("llmProvider") == model_obj.llm_provider
+    assert server_json.get("model") == model_obj.model
+    assert server_json.get("prompt") == model_obj.prompt
+    assert server_json.get("promptVariables") == model_obj.prompt_variables
+    assert server_json.get("stopWords") == model_obj.stop_words
+    assert server_json.get("temperature") == model_obj.temperature
+    assert server_json.get("topP") == model_obj.top_p
+    model_json = model_obj.to_dict()
+    converted_model_json = {}
+    for key, value in model_json.items():
+        camel_key = model_obj.attribute_map.get(key, key)
+        converted_model_json[camel_key] = value
+    for key, value in server_json.items():
+        assert key in converted_model_json
+        assert value == converted_model_json[key]

--- a/tests/serdesertest/test_serdeser_rate_limit.py
+++ b/tests/serdesertest/test_serdeser_rate_limit.py
@@ -1,46 +1,38 @@
-import unittest
 import json
+import re
+
+import pytest
+
 from conductor.client.http.models.rate_limit import RateLimit
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class RateLimitTest(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("RateLimitConfig")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_serialization_deserialization(self):
-        # 1. Server JSON can be correctly deserialized into SDK model object
-        rate_limit = RateLimit(
-            rate_limit_key=self.server_json.get("rateLimitKey"),
-            concurrent_exec_limit=self.server_json.get("concurrentExecLimit"),
-            tag=self.server_json.get("tag"),
-            concurrent_execution_limit=self.server_json.get("concurrentExecutionLimit")
-        )
-
-        # 2. All fields are properly populated during deserialization
-        self.assertEqual(self.server_json.get("rateLimitKey"), rate_limit.rate_limit_key)
-        self.assertEqual(self.server_json.get("concurrentExecLimit"), rate_limit.concurrent_exec_limit)
-        self.assertEqual(self.server_json.get("tag"), rate_limit.tag)
-        self.assertEqual(self.server_json.get("concurrentExecutionLimit"), rate_limit.concurrent_execution_limit)
-
-        # 3. The SDK model can be serialized back to JSON
-        model_dict = rate_limit.to_dict()
-
-        # 4. The resulting JSON matches the original, ensuring no data is lost
-        for key, value in self.server_json.items():
-            snake_key = self._camel_to_snake(key)
-            self.assertIn(snake_key, model_dict)
-            self.assertEqual(value, model_dict[snake_key])
-
-    def _camel_to_snake(self, name):
-        """
-        Convert camelCase to snake_case
-        """
-        import re
-        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("RateLimitConfig"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def camel_to_snake(name):
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def test_serialization_deserialization(server_json):
+    rate_limit = RateLimit(
+        rate_limit_key=server_json.get("rateLimitKey"),
+        concurrent_exec_limit=server_json.get("concurrentExecLimit"),
+        tag=server_json.get("tag"),
+        concurrent_execution_limit=server_json.get("concurrentExecutionLimit"),
+    )
+    assert server_json.get("rateLimitKey") == rate_limit.rate_limit_key
+    assert server_json.get("concurrentExecLimit") == rate_limit.concurrent_exec_limit
+    assert server_json.get("tag") == rate_limit.tag
+    assert (
+        server_json.get("concurrentExecutionLimit")
+        == rate_limit.concurrent_execution_limit
+    )
+    model_dict = rate_limit.to_dict()
+    for key, value in server_json.items():
+        snake_key = camel_to_snake(key)
+        assert snake_key in model_dict
+        assert value == model_dict[snake_key]

--- a/tests/serdesertest/test_serdeser_rerun_workflow_request.py
+++ b/tests/serdesertest/test_serdeser_rerun_workflow_request.py
@@ -1,67 +1,53 @@
-import unittest
 import json
-from copy import deepcopy
+
+import pytest
 
 from conductor.client.http.models import RerunWorkflowRequest
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestRerunWorkflowRequestSerialization(unittest.TestCase):
-    """Test serialization and deserialization of RerunWorkflowRequest."""
-
-    def setUp(self):
-        """Set up test data."""
-        # Get the JSON template for RerunWorkflowRequest
-        self.server_json_str = JsonTemplateResolver.get_json_string("RerunWorkflowRequest")
-        self.request_json = json.loads(self.server_json_str)
-
-        # Create the SDK object for reuse in multiple tests
-        self.request_obj = RerunWorkflowRequest()
-        self.request_obj.re_run_from_workflow_id = self.request_json["reRunFromWorkflowId"]
-        self.request_obj.workflow_input = self.request_json["workflowInput"]
-        self.request_obj.re_run_from_task_id = self.request_json["reRunFromTaskId"]
-        self.request_obj.task_input = self.request_json["taskInput"]
-        self.request_obj.correlation_id = self.request_json["correlationId"]
-
-        # Transform SDK object dict to match server format (for reuse in tests)
-        result_dict = self.request_obj.to_dict()
-        self.transformed_dict = {
-            "reRunFromWorkflowId": result_dict["re_run_from_workflow_id"],
-            "workflowInput": result_dict["workflow_input"],
-            "reRunFromTaskId": result_dict["re_run_from_task_id"],
-            "taskInput": result_dict["task_input"],
-            "correlationId": result_dict["correlation_id"]
-        }
-
-    def test_serialization_deserialization_cycle(self):
-        """Test the complete serialization/deserialization cycle."""
-        # 1. Test deserialization: Assert that fields are correctly populated
-        self.assertEqual(self.request_obj.re_run_from_workflow_id, "sample_reRunFromWorkflowId")
-        self.assertEqual(self.request_obj.re_run_from_task_id, "sample_reRunFromTaskId")
-        self.assertEqual(self.request_obj.correlation_id, "sample_correlationId")
-
-        # Check dictionary fields (maps)
-        self.assertIsInstance(self.request_obj.workflow_input, dict)
-        self.assertEqual(self.request_obj.workflow_input["sample_key"], "sample_value")
-
-        self.assertIsInstance(self.request_obj.task_input, dict)
-        self.assertEqual(self.request_obj.task_input["sample_key"], "sample_value")
-
-        # 2. Test serialization: Compare individual fields
-        self.assertEqual(self.transformed_dict["reRunFromWorkflowId"], self.request_json["reRunFromWorkflowId"])
-        self.assertEqual(self.transformed_dict["reRunFromTaskId"], self.request_json["reRunFromTaskId"])
-        self.assertEqual(self.transformed_dict["correlationId"], self.request_json["correlationId"])
-
-        # Compare dictionary fields
-        self.assertEqual(self.transformed_dict["workflowInput"], self.request_json["workflowInput"])
-        self.assertEqual(self.transformed_dict["taskInput"], self.request_json["taskInput"])
-
-        # 3. Ensure no fields are missing
-        self.assertEqual(set(self.transformed_dict.keys()), set(self.request_json.keys()))
-
-        # 4. Test full cycle with deep equality
-        self.assertEqual(self.transformed_dict, self.request_json)
+@pytest.fixture
+def request_json():
+    return json.loads(JsonTemplateResolver.get_json_string("RerunWorkflowRequest"))
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.fixture
+def request_obj(request_json):
+    obj = RerunWorkflowRequest()
+    obj.re_run_from_workflow_id = request_json["reRunFromWorkflowId"]
+    obj.workflow_input = request_json["workflowInput"]
+    obj.re_run_from_task_id = request_json["reRunFromTaskId"]
+    obj.task_input = request_json["taskInput"]
+    obj.correlation_id = request_json["correlationId"]
+    return obj
+
+
+def test_serialization_deserialization_cycle(request_json, request_obj):
+    result_dict = request_obj.to_dict()
+    transformed_dict = {
+        "reRunFromWorkflowId": result_dict["re_run_from_workflow_id"],
+        "workflowInput": result_dict["workflow_input"],
+        "reRunFromTaskId": result_dict["re_run_from_task_id"],
+        "taskInput": result_dict["task_input"],
+        "correlationId": result_dict["correlation_id"],
+    }
+    # 1. Test deserialization: Assert that fields are correctly populated
+    assert request_obj.re_run_from_workflow_id == "sample_reRunFromWorkflowId"
+    assert request_obj.re_run_from_task_id == "sample_reRunFromTaskId"
+    assert request_obj.correlation_id == "sample_correlationId"
+    assert isinstance(request_obj.workflow_input, dict)
+    assert request_obj.workflow_input["sample_key"] == "sample_value"
+    assert isinstance(request_obj.task_input, dict)
+    assert request_obj.task_input["sample_key"] == "sample_value"
+    # 2. Test serialization: Compare individual fields
+    assert (
+        transformed_dict["reRunFromWorkflowId"] == request_json["reRunFromWorkflowId"]
+    )
+    assert transformed_dict["reRunFromTaskId"] == request_json["reRunFromTaskId"]
+    assert transformed_dict["correlationId"] == request_json["correlationId"]
+    assert transformed_dict["workflowInput"] == request_json["workflowInput"]
+    assert transformed_dict["taskInput"] == request_json["taskInput"]
+    # 3. Ensure no fields are missing
+    assert set(transformed_dict.keys()) == set(request_json.keys())
+    # 4. Test full cycle with deep equality
+    assert transformed_dict == request_json

--- a/tests/serdesertest/test_serdeser_role.py
+++ b/tests/serdesertest/test_serdeser_role.py
@@ -1,75 +1,70 @@
 import json
-import unittest
-from typing import List
 
-from conductor.client.http.models.role import Role
+import pytest
+
 from conductor.client.http.models.permission import Permission
+from conductor.client.http.models.role import Role
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestRoleSerialization(unittest.TestCase):
-    """Test serialization and deserialization of the Role model."""
-
-    def setUp(self):
-        """Set up test fixtures."""
-        self.server_json_str = JsonTemplateResolver.get_json_string("Role")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_role_serialization_deserialization(self):
-        """Test that Role objects can be properly serialized and deserialized."""
-        # 1. Test deserialization from server JSON to SDK model
-        role_obj = Role(
-            name=self.server_json.get('name'),
-            permissions=[Permission(**perm) if isinstance(perm, dict) else perm
-                         for perm in self.server_json.get('permissions', [])]
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get('name'), role_obj.name)
-
-        # Verify permissions list if present
-        if 'permissions' in self.server_json:
-            self.assertIsNotNone(role_obj.permissions)
-            self.assertEqual(len(self.server_json['permissions']), len(role_obj.permissions))
-
-            # Check first permission in list if available
-            if self.server_json['permissions'] and role_obj.permissions:
-                # This would need to be adapted based on the Permission class structure
-                if hasattr(role_obj.permissions[0], 'to_dict'):
-                    permission_dict = role_obj.permissions[0].to_dict()
-                    for key, value in self.server_json['permissions'][0].items():
-                        # Convert JSON camelCase to Python snake_case if needed
-                        snake_key = ''.join(['_' + c.lower() if c.isupper() else c for c in key]).lstrip('_')
-                        if snake_key in permission_dict:
-                            self.assertEqual(value, permission_dict[snake_key])
-
-        # 3. Test serialization back to JSON
-        serialized_json = role_obj.to_dict()
-
-        # 4. Verify the resulting JSON matches the original
-        self.assertEqual(self.server_json.get('name'), serialized_json.get('name'))
-
-        # Compare permissions lists if present
-        if 'permissions' in self.server_json and 'permissions' in serialized_json:
-            self.assertEqual(len(self.server_json['permissions']), len(serialized_json['permissions']))
-
-            # Deeper comparison would depend on Permission class structure
-            if self.server_json['permissions'] and serialized_json['permissions']:
-                # This assumes Permission has a similar structure and serialization logic
-                for i, (orig_perm, serial_perm) in enumerate(
-                        zip(self.server_json['permissions'], serialized_json['permissions'])
-                ):
-                    if isinstance(orig_perm, dict) and isinstance(serial_perm, dict):
-                        for key in orig_perm:
-                            snake_key = ''.join(['_' + c.lower() if c.isupper() else c for c in key]).lstrip('_')
-                            camel_key = ''.join(
-                                [word.capitalize() if i > 0 else word for i, word in enumerate(snake_key.split('_'))]
-                            )
-                            self.assertTrue(
-                                key in serial_perm or camel_key in serial_perm,
-                                f"Key {key} or {camel_key} missing from serialized permission"
-                            )
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("Role")
+    return json.loads(server_json_str)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_role_serialization_deserialization(server_json):
+    """Test that Role objects can be properly serialized and deserialized."""
+    # 1. Test deserialization from server JSON to SDK model
+    role_obj = Role(
+        name=server_json.get("name"),
+        permissions=[
+            Permission(**perm) if isinstance(perm, dict) else perm
+            for perm in server_json.get("permissions", [])
+        ],
+    )
+    # 2. Verify all fields are properly populated
+    assert server_json.get("name") == role_obj.name
+    # Verify permissions list if present
+    if "permissions" in server_json:
+        assert role_obj.permissions is not None
+        assert len(server_json["permissions"]) == len(role_obj.permissions)
+        # Check first permission in list if available
+        if server_json["permissions"] and role_obj.permissions:
+            # This would need to be adapted based on the Permission class structure
+            if hasattr(role_obj.permissions[0], "to_dict"):
+                permission_dict = role_obj.permissions[0].to_dict()
+                for key, value in server_json["permissions"][0].items():
+                    # Convert JSON camelCase to Python snake_case if needed
+                    snake_key = "".join(
+                        ["_" + c.lower() if c.isupper() else c for c in key]
+                    ).lstrip("_")
+                    if snake_key in permission_dict:
+                        assert value == permission_dict[snake_key]
+    # 3. Test serialization back to JSON
+    serialized_json = role_obj.to_dict()
+    # 4. Verify the resulting JSON matches the original
+    assert server_json.get("name") == serialized_json.get("name")
+    # Compare permissions lists if present
+    if "permissions" in server_json and "permissions" in serialized_json:
+        assert len(server_json["permissions"]) == len(serialized_json["permissions"])
+        # Deeper comparison would depend on Permission class structure
+        if server_json["permissions"] and serialized_json["permissions"]:
+            # This assumes Permission has a similar structure and serialization logic
+            for i, (orig_perm, serial_perm) in enumerate(
+                zip(server_json["permissions"], serialized_json["permissions"])
+            ):
+                if isinstance(orig_perm, dict) and isinstance(serial_perm, dict):
+                    for key in orig_perm:
+                        snake_key = "".join(
+                            ["_" + c.lower() if c.isupper() else c for c in key]
+                        ).lstrip("_")
+                        camel_key = "".join(
+                            [
+                                word.capitalize() if i > 0 else word
+                                for i, word in enumerate(snake_key.split("_"))
+                            ]
+                        )
+                        assert (
+                            key in serial_perm or camel_key in serial_perm
+                        ), f"Key {key} or {camel_key} missing from serialized permission"

--- a/tests/serdesertest/test_serdeser_save_schedule_request.py
+++ b/tests/serdesertest/test_serdeser_save_schedule_request.py
@@ -1,96 +1,79 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.save_schedule_request import SaveScheduleRequest
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestSaveScheduleRequestSerDes(unittest.TestCase):
-    """
-    Unit tests for serialization and deserialization of SaveScheduleRequest model
-    """
-
-    def setUp(self):
-        # Load JSON template instead of hardcoding
-        self.server_json_str = JsonTemplateResolver.get_json_string("SaveScheduleRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_save_schedule_request_serde(self):
-        """Test serialization and deserialization of SaveScheduleRequest model"""
-
-        # 1. Create model object using constructor
-        request = SaveScheduleRequest(
-            name=self.server_json.get('name'),
-            cron_expression=self.server_json.get('cronExpression'),
-            run_catchup_schedule_instances=self.server_json.get('runCatchupScheduleInstances'),
-            paused=self.server_json.get('paused'),
-            start_workflow_request=self.server_json.get('startWorkflowRequest'),
-            created_by=self.server_json.get('createdBy'),
-            updated_by=self.server_json.get('updatedBy'),
-            schedule_start_time=self.server_json.get('scheduleStartTime'),
-            schedule_end_time=self.server_json.get('scheduleEndTime'),
-            zone_id=self.server_json.get('zoneId'),
-            description=self.server_json.get('description')
-        )
-
-        # 2. Verify all fields are populated correctly during creation
-        self._verify_fields(request, self.server_json)
-
-        # 3. Serialize model object back to JSON
-        result_json = request.to_dict()
-
-        # 4. Verify serialized JSON matches the original JSON
-        self._verify_json_match(result_json, self.server_json)
-
-    def _verify_fields(self, model, json_data):
-        """Verify all fields in the model match their corresponding JSON values"""
-        # Direct field-to-field mapping verification
-        self.assertEqual(model.name, json_data.get('name'), "Field 'name' mismatch")
-        self.assertEqual(model.cron_expression, json_data.get('cronExpression'), "Field 'cron_expression' mismatch")
-        self.assertEqual(model.run_catchup_schedule_instances, json_data.get('runCatchupScheduleInstances'),
-                         "Field 'run_catchup_schedule_instances' mismatch")
-        self.assertEqual(model.paused, json_data.get('paused'), "Field 'paused' mismatch")
-
-        # Object field handling - assuming StartWorkflowRequest is similarly structured
-        # For nested objects, you might need more complex verification
-        if json_data.get('startWorkflowRequest') is not None:
-            self.assertIsNotNone(model.start_workflow_request, "Field 'start_workflow_request' should not be None")
-
-        self.assertEqual(model.created_by, json_data.get('createdBy'), "Field 'created_by' mismatch")
-        self.assertEqual(model.updated_by, json_data.get('updatedBy'), "Field 'updated_by' mismatch")
-        self.assertEqual(model.schedule_start_time, json_data.get('scheduleStartTime'),
-                         "Field 'schedule_start_time' mismatch")
-        self.assertEqual(model.schedule_end_time, json_data.get('scheduleEndTime'),
-                         "Field 'schedule_end_time' mismatch")
-        self.assertEqual(model.zone_id, json_data.get('zoneId'), "Field 'zone_id' mismatch")
-        self.assertEqual(model.description, json_data.get('description'), "Field 'description' mismatch")
-
-    def _verify_json_match(self, result_json, original_json):
-        """Verify serialized JSON matches the original JSON, accounting for camelCase/snake_case differences"""
-        # Map Python snake_case to JSON camelCase for comparison
-        field_mapping = {
-            'name': 'name',
-            'cron_expression': 'cronExpression',
-            'run_catchup_schedule_instances': 'runCatchupScheduleInstances',
-            'paused': 'paused',
-            'start_workflow_request': 'startWorkflowRequest',
-            'created_by': 'createdBy',
-            'updated_by': 'updatedBy',
-            'schedule_start_time': 'scheduleStartTime',
-            'schedule_end_time': 'scheduleEndTime',
-            'zone_id': 'zoneId',
-            'description': 'description'
-        }
-
-        # Check each field to ensure it matches between result and original
-        for py_field, json_field in field_mapping.items():
-            # Skip comparison for None values if they don't exist in original
-            if py_field in result_json and json_field in original_json:
-                self.assertEqual(
-                    result_json[py_field],
-                    original_json[json_field],
-                    f"Field mismatch: {py_field}/{json_field}"
-                )
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("SaveScheduleRequest")
+    return json.loads(server_json_str)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def verify_fields(model, json_data):
+    assert model.name == json_data.get("name"), "Field 'name' mismatch"
+    assert model.cron_expression == json_data.get(
+        "cronExpression"
+    ), "Field 'cron_expression' mismatch"
+    assert model.run_catchup_schedule_instances == json_data.get(
+        "runCatchupScheduleInstances"
+    ), "Field 'run_catchup_schedule_instances' mismatch"
+    assert model.paused == json_data.get("paused"), "Field 'paused' mismatch"
+    if json_data.get("startWorkflowRequest") is not None:
+        assert (
+            model.start_workflow_request is not None
+        ), "Field 'start_workflow_request' should not be None"
+    assert model.created_by == json_data.get("createdBy"), "Field 'created_by' mismatch"
+    assert model.updated_by == json_data.get("updatedBy"), "Field 'updated_by' mismatch"
+    assert model.schedule_start_time == json_data.get(
+        "scheduleStartTime"
+    ), "Field 'schedule_start_time' mismatch"
+    assert model.schedule_end_time == json_data.get(
+        "scheduleEndTime"
+    ), "Field 'schedule_end_time' mismatch"
+    assert model.zone_id == json_data.get("zoneId"), "Field 'zone_id' mismatch"
+    assert model.description == json_data.get(
+        "description"
+    ), "Field 'description' mismatch"
+
+
+def verify_json_match(result_json, original_json):
+    field_mapping = {
+        "name": "name",
+        "cron_expression": "cronExpression",
+        "run_catchup_schedule_instances": "runCatchupScheduleInstances",
+        "paused": "paused",
+        "start_workflow_request": "startWorkflowRequest",
+        "created_by": "createdBy",
+        "updated_by": "updatedBy",
+        "schedule_start_time": "scheduleStartTime",
+        "schedule_end_time": "scheduleEndTime",
+        "zone_id": "zoneId",
+        "description": "description",
+    }
+    for py_field, json_field in field_mapping.items():
+        if py_field in result_json and json_field in original_json:
+            assert (
+                result_json[py_field] == original_json[json_field]
+            ), f"Field mismatch: {py_field}/{json_field}"
+
+
+def test_save_schedule_request_serde(server_json):
+    request = SaveScheduleRequest(
+        name=server_json.get("name"),
+        cron_expression=server_json.get("cronExpression"),
+        run_catchup_schedule_instances=server_json.get("runCatchupScheduleInstances"),
+        paused=server_json.get("paused"),
+        start_workflow_request=server_json.get("startWorkflowRequest"),
+        created_by=server_json.get("createdBy"),
+        updated_by=server_json.get("updatedBy"),
+        schedule_start_time=server_json.get("scheduleStartTime"),
+        schedule_end_time=server_json.get("scheduleEndTime"),
+        zone_id=server_json.get("zoneId"),
+        description=server_json.get("description"),
+    )
+    verify_fields(request, server_json)
+    result_json = request.to_dict()
+    verify_json_match(result_json, server_json)

--- a/tests/serdesertest/test_serdeser_schema_def.py
+++ b/tests/serdesertest/test_serdeser_schema_def.py
@@ -1,68 +1,51 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.schema_def import SchemaDef, SchemaType
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestSchemaDefSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("SchemaDef")
-        self.server_json = json.loads(self.server_json_str)
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("SchemaDef"))
 
-    def test_schema_def_serdes(self):
-        # 1. Create a SchemaDef instance with all fields from the JSON
-        schema_def = SchemaDef(
-            name=self.server_json.get("name"),
-            version=self.server_json.get("version"),
-            type=SchemaType(self.server_json.get("type")) if self.server_json.get("type") else None,
-            data=self.server_json.get("data"),
-            external_ref=self.server_json.get("externalRef")
-        )
 
-        # Set the auditable fields
-        schema_def.owner_app = self.server_json.get("ownerApp")
-        schema_def.create_time = self.server_json.get("createTime")
-        schema_def.update_time = self.server_json.get("updateTime")
-        schema_def.created_by = self.server_json.get("createdBy")
-        schema_def.updated_by = self.server_json.get("updatedBy")
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get("name"), schema_def.name)
-        self.assertEqual(self.server_json.get("version"), schema_def.version)
-        if self.server_json.get("type"):
-            self.assertEqual(SchemaType(self.server_json.get("type")), schema_def.type)
-        self.assertEqual(self.server_json.get("data"), schema_def.data)
-        self.assertEqual(self.server_json.get("externalRef"), schema_def.external_ref)
-        self.assertEqual(self.server_json.get("ownerApp"), schema_def.owner_app)
-        self.assertEqual(self.server_json.get("createTime"), schema_def.create_time)
-        self.assertEqual(self.server_json.get("updateTime"), schema_def.update_time)
-        self.assertEqual(self.server_json.get("createdBy"), schema_def.created_by)
-        self.assertEqual(self.server_json.get("updatedBy"), schema_def.updated_by)
-
-        # 3. Test serialization from SDK model back to JSON
-        model_dict = schema_def.to_dict()
-
-        # Create the expected JSON with proper field mappings
-        model_json = {}
-
-        # Map the fields using the attribute_map
-        for attr, json_key in {**SchemaDef.attribute_map}.items():
-            value = model_dict.get(attr)
-            if value is not None:
-                if attr == "type" and value is not None:
-                    model_json[json_key] = str(value)
-                else:
-                    model_json[json_key] = value
-
-        # 4. Verify the resulting JSON matches the original
-        for key, value in self.server_json.items():
-            if key == "type" and value is not None and model_json.get(key) is not None:
-                # Handle enum conversion
-                self.assertEqual(value, model_json.get(key))
+def test_schema_def_serdes(server_json):
+    schema_def = SchemaDef(
+        name=server_json.get("name"),
+        version=server_json.get("version"),
+        type=SchemaType(server_json.get("type")) if server_json.get("type") else None,
+        data=server_json.get("data"),
+        external_ref=server_json.get("externalRef"),
+    )
+    schema_def.owner_app = server_json.get("ownerApp")
+    schema_def.create_time = server_json.get("createTime")
+    schema_def.update_time = server_json.get("updateTime")
+    schema_def.created_by = server_json.get("createdBy")
+    schema_def.updated_by = server_json.get("updatedBy")
+    assert server_json.get("name") == schema_def.name
+    assert server_json.get("version") == schema_def.version
+    if server_json.get("type"):
+        assert SchemaType(server_json.get("type")) == schema_def.type
+    assert server_json.get("data") == schema_def.data
+    assert server_json.get("externalRef") == schema_def.external_ref
+    assert server_json.get("ownerApp") == schema_def.owner_app
+    assert server_json.get("createTime") == schema_def.create_time
+    assert server_json.get("updateTime") == schema_def.update_time
+    assert server_json.get("createdBy") == schema_def.created_by
+    assert server_json.get("updatedBy") == schema_def.updated_by
+    model_dict = schema_def.to_dict()
+    model_json = {}
+    for attr, json_key in {**SchemaDef.attribute_map}.items():
+        value = model_dict.get(attr)
+        if value is not None:
+            if attr == "type" and value is not None:
+                model_json[json_key] = str(value)
             else:
-                self.assertEqual(value, model_json.get(key), f"Field {key} doesn't match")
-
-
-if __name__ == '__main__':
-    unittest.main()
+                model_json[json_key] = value
+    for key, value in server_json.items():
+        if key == "type" and value is not None and model_json.get(key) is not None:
+            assert value == model_json.get(key)
+        else:
+            assert value == model_json.get(key), f"Field {key} doesn't match"

--- a/tests/serdesertest/test_serdeser_search_result_task.py
+++ b/tests/serdesertest/test_serdeser_search_result_task.py
@@ -1,65 +1,35 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.search_result_task import SearchResultTask
 from conductor.client.http.models.task import Task
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestSearchResultTaskSerDes(unittest.TestCase):
-    """Test serialization and deserialization of SearchResultTask model."""
-
-    def setUp(self):
-        """Set up test environment."""
-        self.server_json_str = JsonTemplateResolver.get_json_string("SearchResult")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_search_result_task_ser_des(self):
-        """
-        Test that verifies:
-        1. Server JSON can be correctly deserialized into SDK model object
-        2. All fields are properly populated during deserialization
-        3. The SDK model can be serialized back to JSON
-        4. The resulting JSON matches the original
-        """
-        # Create sample Task object for results
-        task = Task()
-
-        # 1. Deserialize JSON into model object
-        search_result = SearchResultTask(
-            total_hits=self.server_json.get("totalHits"),
-            results=[task] if self.server_json.get("results") else None
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(search_result.total_hits, self.server_json.get("totalHits"))
-
-        # Verify results field - depending on what's in the template
-        if self.server_json.get("results"):
-            self.assertIsNotNone(search_result.results)
-            self.assertEqual(len(search_result.results), len(self.server_json.get("results")))
-        else:
-            # If results is null in JSON, it should be None in the object
-            if "results" in self.server_json and self.server_json["results"] is None:
-                self.assertIsNone(search_result.results)
-
-        # 3. Serialize model back to dictionary
-        serialized_dict = search_result.to_dict()
-
-        # 4. Verify the serialized JSON matches the original
-        # Check totalHits field
-        if "totalHits" in self.server_json:
-            self.assertEqual(serialized_dict.get("total_hits"), self.server_json.get("totalHits"))
-
-        # Check results field - this check will depend on Task serialization
-        # which isn't fully testable without a complete Task implementation
-        if "results" in self.server_json and self.server_json["results"] is not None:
-            self.assertIsNotNone(serialized_dict.get("results"))
-            # Basic length check
-            self.assertEqual(len(serialized_dict.get("results")), len(self.server_json.get("results")))
-        elif "results" in self.server_json and self.server_json["results"] is None:
-            # If null in original, should be None after round-trip
-            self.assertIsNone(serialized_dict.get("results"))
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("SearchResult"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_search_result_task_ser_des(server_json):
+    task = Task()
+    search_result = SearchResultTask(
+        total_hits=server_json.get("totalHits"),
+        results=[task] if server_json.get("results") else None,
+    )
+    assert search_result.total_hits == server_json.get("totalHits")
+    if server_json.get("results"):
+        assert search_result.results is not None
+        assert len(search_result.results) == len(server_json.get("results"))
+    else:
+        if "results" in server_json and server_json["results"] is None:
+            assert search_result.results is None
+    serialized_dict = search_result.to_dict()
+    if "totalHits" in server_json:
+        assert serialized_dict.get("total_hits") == server_json.get("totalHits")
+    if "results" in server_json and server_json["results"] is not None:
+        assert serialized_dict.get("results") is not None
+        assert len(serialized_dict.get("results")) == len(server_json.get("results"))
+    elif "results" in server_json and server_json["results"] is None:
+        assert serialized_dict.get("results") is None

--- a/tests/serdesertest/test_serdeser_search_result_task_summary.py
+++ b/tests/serdesertest/test_serdeser_search_result_task_summary.py
@@ -1,59 +1,50 @@
-import unittest
-from conductor.client.http.models.search_result_task_summary import SearchResultTaskSummary
-from conductor.client.http.models.task_summary import TaskSummary
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 import json
 
+import pytest
 
-class TestSearchResultTaskSummarySerDeser(unittest.TestCase):
-    """Test serialization and deserialization of SearchResultTaskSummary model"""
-
-    def setUp(self):
-        """Set up test fixtures"""
-        self.server_json_str = JsonTemplateResolver.get_json_string("SearchResult")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_search_result_task_summary_serdeser(self):
-        """Test serialization and deserialization of SearchResultTaskSummary"""
-        task_summary = TaskSummary()
-        # 1. Test deserialization of server JSON into SDK model
-        model = SearchResultTaskSummary(
-            total_hits=self.server_json.get("totalHits"),
-            results=[task_summary] if self.server_json.get("results") else None
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(model.total_hits, self.server_json.get("totalHits"))
-        self.assertEqual(len(model.results), len(self.server_json.get("results", [])))
-
-        # Verify each TaskSummary in results list
-        for i, task_summary in enumerate(model.results):
-            original_task = self.server_json.get("results")[i]
-            # Assuming TaskSummary has properties that correspond to the JSON fields
-            # Add specific assertions for TaskSummary fields here
-            self.assertTrue(isinstance(task_summary, TaskSummary))
-
-        # 3. Test serialization back to JSON
-        model_dict = model.to_dict()
-
-        # 4. Verify the resulting JSON matches the original
-        self.assertEqual(model_dict.get("total_hits"), self.server_json.get("totalHits"))
-        self.assertEqual(len(model_dict.get("results", [])), len(self.server_json.get("results", [])))
-
-        # Check field transformation from snake_case to camelCase
-        serialized_json = {}
-        for attr, json_key in model.attribute_map.items():
-            if attr in model_dict:
-                serialized_json[json_key] = model_dict[attr]
-
-        # Compare serialized JSON with original (considering camelCase transformation)
-        for key in self.server_json:
-            if key == "results":
-                # For lists, compare length
-                self.assertEqual(len(serialized_json.get(key, [])), len(self.server_json.get(key, [])))
-            else:
-                self.assertEqual(serialized_json.get(key), self.server_json.get(key))
+from conductor.client.http.models.search_result_task_summary import (
+    SearchResultTaskSummary,
+)
+from conductor.client.http.models.task_summary import TaskSummary
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("SearchResult")
+    return json.loads(server_json_str)
+
+
+def test_search_result_task_summary_serdeser(server_json):
+    """Test serialization and deserialization of SearchResultTaskSummary"""
+    task_summary = TaskSummary()
+    # 1. Test deserialization of server JSON into SDK model
+    model = SearchResultTaskSummary(
+        total_hits=server_json.get("totalHits"),
+        results=[task_summary] if server_json.get("results") else None,
+    )
+    # 2. Verify all fields are properly populated
+    assert model.total_hits == server_json.get("totalHits")
+    assert len(model.results) == len(server_json.get("results", []))
+    # Verify each TaskSummary in results list
+    for i, task_summary in enumerate(model.results):
+        # Assuming TaskSummary has properties that correspond to the JSON fields
+        # Add specific assertions for TaskSummary fields here
+        assert isinstance(task_summary, TaskSummary)
+    # 3. Test serialization back to JSON
+    model_dict = model.to_dict()
+    # 4. Verify the resulting JSON matches the original
+    assert model_dict.get("total_hits") == server_json.get("totalHits")
+    assert len(model_dict.get("results", [])) == len(server_json.get("results", []))
+    # Check field transformation from snake_case to camelCase
+    serialized_json = {}
+    for attr, json_key in model.attribute_map.items():
+        if attr in model_dict:
+            serialized_json[json_key] = model_dict[attr]
+    # Compare serialized JSON with original (considering camelCase transformation)
+    for key in server_json:
+        if key == "results":
+            # For lists, compare length
+            assert len(serialized_json.get(key, [])) == len(server_json.get(key, []))
+        else:
+            assert serialized_json.get(key) == server_json.get(key)

--- a/tests/serdesertest/test_serdeser_search_result_workflow.py
+++ b/tests/serdesertest/test_serdeser_search_result_workflow.py
@@ -1,68 +1,35 @@
-import unittest
+import json
+
+import pytest
+
 from conductor.client.http.models.search_result_workflow import SearchResultWorkflow
 from conductor.client.http.models.workflow import Workflow
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
-import json
 
 
-class TestSearchResultWorkflow(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("SearchResult")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_search_result_workflow_serde(self):
-        """Test serialization and deserialization of SearchResultWorkflow"""
-
-        # 1. Deserialize JSON into SDK model
-        model = SearchResultWorkflow()
-
-        # Manually map JSON fields to model attributes
-        if "totalHits" in self.server_json:
-            model.total_hits = self.server_json["totalHits"]
-
-        # For the results list, we need to create Workflow objects
-        if "results" in self.server_json and self.server_json["results"]:
-            workflow_list = []
-            for workflow_json in self.server_json["results"]:
-                workflow = Workflow()
-                # Populate workflow object (assuming Workflow has proper setters)
-                # This would depend on the structure of Workflow class
-                workflow_list.append(workflow)
-
-            model.results = workflow_list
-
-        # 2. Verify all fields are properly populated
-        self.assertIsNotNone(model.total_hits)
-        self.assertIsNotNone(model.results)
-        if model.results:
-            self.assertIsInstance(model.results[0], Workflow)
-
-        # 3. Serialize back to JSON
-        model_dict = model.to_dict()
-        model_json = json.dumps(model_dict)
-
-        # 4. Verify the serialized JSON matches the original
-        deserialized_json = json.loads(model_json)
-
-        # Check totalHits field (camelCase to snake_case transformation)
-        self.assertEqual(
-            self.server_json.get("totalHits"),
-            deserialized_json.get("total_hits")
-        )
-
-        # Check results field
-        self.assertEqual(
-            len(self.server_json.get("results", [])),
-            len(deserialized_json.get("results", []))
-        )
-
-        # Additional assertion for nested structures if needed
-        if self.server_json.get("results") and deserialized_json.get("results"):
-            # This assumes the Workflow class properly handles its own serialization
-            # Add more detailed checks for the Workflow objects if needed
-            pass
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("SearchResult"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_search_result_workflow_serde(server_json):
+    model = SearchResultWorkflow()
+    if "totalHits" in server_json:
+        model.total_hits = server_json["totalHits"]
+    if server_json.get("results"):
+        workflow_list = []
+        for workflow_json in server_json["results"]:
+            workflow = Workflow()
+            workflow_list.append(workflow)
+        model.results = workflow_list
+    assert model.total_hits is not None
+    assert model.results is not None
+    if model.results:
+        assert isinstance(model.results[0], Workflow)
+    model_dict = model.to_dict()
+    model_json = json.dumps(model_dict)
+    deserialized_json = json.loads(model_json)
+    assert server_json.get("totalHits") == deserialized_json.get("total_hits")
+    assert len(server_json.get("results", [])) == len(
+        deserialized_json.get("results", [])
+    )

--- a/tests/serdesertest/test_serdeser_search_result_workflow_schedule_execution_model.py
+++ b/tests/serdesertest/test_serdeser_search_result_workflow_schedule_execution_model.py
@@ -1,60 +1,36 @@
-import unittest
-from conductor.client.http.models.search_result_workflow_schedule_execution_model import \
-    SearchResultWorkflowScheduleExecutionModel
-from conductor.client.http.models.workflow_schedule_execution_model import WorkflowScheduleExecutionModel
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 import json
 
+import pytest
 
-class TestSearchResultWorkflowScheduleExecutionModel(unittest.TestCase):
-    """
-    Test case for SearchResultWorkflowScheduleExecutionModel
-    """
-
-    def setUp(self):
-        """
-        Set up test fixtures
-        """
-        self.server_json_str = JsonTemplateResolver.get_json_string("SearchResult")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_search_result_workflow_schedule_execution_model_serde(self):
-        """
-        Test serialization and deserialization of SearchResultWorkflowScheduleExecutionModel
-        """
-        work_flow_schedule_execution_model = WorkflowScheduleExecutionModel()
-        # 1. Deserialization: Server JSON to SDK model
-        model = SearchResultWorkflowScheduleExecutionModel(
-            total_hits=self.server_json['totalHits'],
-            results=[work_flow_schedule_execution_model] if self.server_json.get("results") else None
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(model.total_hits, self.server_json['totalHits'])
-        self.assertEqual(len(model.results), len(self.server_json['results']))
-
-        # Check sample result item if available
-        if model.results and len(model.results) > 0:
-            sample_result = model.results[0]
-            self.assertIsInstance(sample_result, WorkflowScheduleExecutionModel)
-
-            # Verify fields in each result item
-            # Note: Add assertions for WorkflowScheduleExecutionModel fields based on expected structure
-            # This would vary based on the actual model properties
-
-        # 3. Serialization: SDK model back to JSON
-        model_dict = model.to_dict()
-
-        # 4. Verify serialized JSON matches original
-        self.assertEqual(model_dict['total_hits'], self.server_json['totalHits'])
-
-        # Verify results list
-        self.assertEqual(len(model_dict['results']), len(self.server_json['results']))
-
-        # Check field transformations between camelCase and snake_case
-        self.assertTrue('total_hits' in model_dict)
-        self.assertTrue('results' in model_dict)
+from conductor.client.http.models.search_result_workflow_schedule_execution_model import (
+    SearchResultWorkflowScheduleExecutionModel,
+)
+from conductor.client.http.models.workflow_schedule_execution_model import (
+    WorkflowScheduleExecutionModel,
+)
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("SearchResult"))
+
+
+def test_search_result_workflow_schedule_execution_model_serde(server_json):
+    work_flow_schedule_execution_model = WorkflowScheduleExecutionModel()
+    model = SearchResultWorkflowScheduleExecutionModel(
+        total_hits=server_json["totalHits"],
+        results=(
+            [work_flow_schedule_execution_model] if server_json.get("results") else None
+        ),
+    )
+    assert model.total_hits == server_json["totalHits"]
+    assert len(model.results) == len(server_json["results"])
+    if model.results and len(model.results) > 0:
+        sample_result = model.results[0]
+        assert isinstance(sample_result, WorkflowScheduleExecutionModel)
+    model_dict = model.to_dict()
+    assert model_dict["total_hits"] == server_json["totalHits"]
+    assert len(model_dict["results"]) == len(server_json["results"])
+    assert "total_hits" in model_dict
+    assert "results" in model_dict

--- a/tests/serdesertest/test_serdeser_search_result_workflow_summary.py
+++ b/tests/serdesertest/test_serdeser_search_result_workflow_summary.py
@@ -1,69 +1,29 @@
-import unittest
 import json
-from conductor.client.http.models.search_result_workflow_summary import SearchResultWorkflowSummary
+
+import pytest
+
+from conductor.client.http.models.search_result_workflow_summary import (
+    SearchResultWorkflowSummary,
+)
 from conductor.client.http.models.workflow_summary import WorkflowSummary
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestSearchResultWorkflowSummary(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("SearchResult")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_serialization_deserialization(self):
-        workflow_summary = WorkflowSummary()
-        # 1. Deserialize JSON to model object
-        model = SearchResultWorkflowSummary(
-            total_hits=self.server_json.get("totalHits"),
-            results=[workflow_summary] if self.server_json.get("results") else None
-        )
-
-        # 2. Verify fields are properly populated
-        self.assertEqual(model.total_hits, self.server_json.get("totalHits"))
-        if model.results:
-            self.assertEqual(len(model.results), len(self.server_json.get("results", [])))
-
-        # Verify specific fields in the first result if available
-        if model.results and len(model.results) > 0:
-            first_result = model.results[0]
-            # Add specific assertions for WorkflowSummary fields here based on your model structure
-
-        # 3. Serialize model back to dictionary
-        serialized_dict = model.to_dict()
-
-        # 4. Verify the serialized dictionary matches the original JSON
-        # Check total_hits field
-        self.assertEqual(serialized_dict["total_hits"], self.server_json.get("totalHits"))
-
-        # Check results array
-        if "results" in serialized_dict and serialized_dict["results"]:
-            self.assertEqual(len(serialized_dict["results"]), len(self.server_json.get("results", [])))
-
-        # Create a custom JSON encoder to handle sets
-        class SetEncoder(json.JSONEncoder):
-            def default(self, obj):
-                if isinstance(obj, set):
-                    return list(obj)
-                return super().default(obj)
-
-        # Convert both to JSON strings for comparison using the custom encoder
-        serialized_json = json.dumps(serialized_dict, sort_keys=True, cls=SetEncoder)
-
-        # Create a comparable dictionary with correct field mappings
-        comparable_dict = {
-            "total_hits": self.server_json.get("totalHits"),
-            "results": []
-        }
-
-        if self.server_json.get("results"):
-            comparable_dict["results"] = [{}] * len(self.server_json.get("results"))
-
-        original_json_comparable = json.dumps(comparable_dict, sort_keys=True)
-
-        # Perform individual field comparisons instead of full JSON comparison
-        # This avoids issues with different field naming conventions
-        self.assertEqual(serialized_dict["total_hits"], self.server_json.get("totalHits"))
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("SearchResult"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_serialization_deserialization(server_json):
+    workflow_summary = WorkflowSummary()
+    model = SearchResultWorkflowSummary(
+        total_hits=server_json.get("totalHits"),
+        results=[workflow_summary] if server_json.get("results") else None,
+    )
+    assert model.total_hits == server_json.get("totalHits")
+    if model.results:
+        assert len(model.results) == len(server_json.get("results", []))
+    serialized_dict = model.to_dict()
+    assert serialized_dict["total_hits"] == server_json.get("totalHits")
+    if serialized_dict.get("results"):
+        assert len(serialized_dict["results"]) == len(server_json.get("results", []))

--- a/tests/serdesertest/test_serdeser_skip_task_request.py
+++ b/tests/serdesertest/test_serdeser_skip_task_request.py
@@ -1,47 +1,39 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.skip_task_request import SkipTaskRequest
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestSkipTaskRequestSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("SkipTaskRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_skip_task_request_serde(self):
-        # 1. Deserialize server JSON to model using constructor
-        model = SkipTaskRequest(
-            task_input=self.server_json.get('taskInput'),
-            task_output=self.server_json.get('taskOutput')
-        )
-
-        # 2. Verify all fields populated correctly
-        self.assertEqual(self.server_json.get('taskInput'), model.task_input)
-        self.assertEqual(self.server_json.get('taskOutput'), model.task_output)
-
-        # Verify nested structures if they exist
-        if isinstance(model.task_input, dict):
-            for key, value in self.server_json.get('taskInput').items():
-                self.assertEqual(value, model.task_input.get(key))
-
-        if isinstance(model.task_output, dict):
-            for key, value in self.server_json.get('taskOutput').items():
-                self.assertEqual(value, model.task_output.get(key))
-
-        # 3. Create a dict manually matching the server format
-        json_from_model = {
-            'taskInput': model.task_input,
-            'taskOutput': model.task_output
-        }
-
-        # Remove None values
-        json_from_model = {k: v for k, v in json_from_model.items() if v is not None}
-
-        # 4. Compare with original JSON
-        self.assertEqual(self.server_json, json_from_model)
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("SkipTaskRequest")
+    return json.loads(server_json_str)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_skip_task_request_serde(server_json):
+    # 1. Deserialize server JSON to model using constructor
+    model = SkipTaskRequest(
+        task_input=server_json.get("taskInput"),
+        task_output=server_json.get("taskOutput"),
+    )
+    # 2. Verify all fields populated correctly
+    assert server_json.get("taskInput") == model.task_input
+    assert server_json.get("taskOutput") == model.task_output
+    # Verify nested structures if they exist
+    if isinstance(model.task_input, dict):
+        for key, value in server_json.get("taskInput").items():
+            assert value == model.task_input.get(key)
+    if isinstance(model.task_output, dict):
+        for key, value in server_json.get("taskOutput").items():
+            assert value == model.task_output.get(key)
+    # 3. Create a dict manually matching the server format
+    json_from_model = {
+        "taskInput": model.task_input,
+        "taskOutput": model.task_output,
+    }
+    # Remove None values
+    json_from_model = {k: v for k, v in json_from_model.items() if v is not None}
+    # 4. Compare with original JSON
+    assert server_json == json_from_model

--- a/tests/serdesertest/test_serdeser_start_workflow.py
+++ b/tests/serdesertest/test_serdeser_start_workflow.py
@@ -1,60 +1,45 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.start_workflow import StartWorkflow
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestStartWorkflowSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("EventHandler.StartWorkflow")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_serdes_start_workflow(self):
-        # 1. Test deserialization of JSON to model
-        model = StartWorkflow(
-            name=self.server_json.get("name"),
-            version=self.server_json.get("version"),
-            correlation_id=self.server_json.get("correlationId"),
-            input=self.server_json.get("input"),
-            task_to_domain=self.server_json.get("taskToDomain")
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get("name"), model.name)
-        self.assertEqual(self.server_json.get("version"), model.version)
-        self.assertEqual(self.server_json.get("correlationId"), model.correlation_id)
-
-        # Verify maps are properly populated
-        if "input" in self.server_json:
-            self.assertIsNotNone(model.input)
-            self.assertEqual(self.server_json.get("input"), model.input)
-            # Check sample values based on template expectations
-            if isinstance(model.input, dict) and len(model.input) > 0:
-                # Verify the structure matches what we expect
-                first_key = next(iter(model.input))
-                self.assertIsNotNone(first_key)
-
-        if "taskToDomain" in self.server_json:
-            self.assertIsNotNone(model.task_to_domain)
-            self.assertEqual(self.server_json.get("taskToDomain"), model.task_to_domain)
-            # Check sample values for task_to_domain
-            if isinstance(model.task_to_domain, dict) and len(model.task_to_domain) > 0:
-                first_key = next(iter(model.task_to_domain))
-                self.assertIsNotNone(first_key)
-                self.assertIsInstance(model.task_to_domain[first_key], str)
-
-        # 3. Test serialization of model back to JSON
-        model_dict = model.to_dict()
-
-        # 4. Verify the resulting JSON matches the original with field name transformations
-        # Checking camelCase (JSON) to snake_case (Python) transformations
-        self.assertEqual(self.server_json.get("name"), model_dict.get("name"))
-        self.assertEqual(self.server_json.get("version"), model_dict.get("version"))
-        self.assertEqual(self.server_json.get("correlationId"), model_dict.get("correlation_id"))
-        self.assertEqual(self.server_json.get("input"), model_dict.get("input"))
-        self.assertEqual(self.server_json.get("taskToDomain"), model_dict.get("task_to_domain"))
+@pytest.fixture
+def server_json():
+    return json.loads(
+        JsonTemplateResolver.get_json_string("EventHandler.StartWorkflow")
+    )
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_serdes_start_workflow(server_json):
+    model = StartWorkflow(
+        name=server_json.get("name"),
+        version=server_json.get("version"),
+        correlation_id=server_json.get("correlationId"),
+        input=server_json.get("input"),
+        task_to_domain=server_json.get("taskToDomain"),
+    )
+    assert server_json.get("name") == model.name
+    assert server_json.get("version") == model.version
+    assert server_json.get("correlationId") == model.correlation_id
+    if "input" in server_json:
+        assert model.input is not None
+        assert server_json.get("input") == model.input
+        if isinstance(model.input, dict) and len(model.input) > 0:
+            first_key = next(iter(model.input))
+            assert first_key is not None
+    if "taskToDomain" in server_json:
+        assert model.task_to_domain is not None
+        assert server_json.get("taskToDomain") == model.task_to_domain
+        if isinstance(model.task_to_domain, dict) and len(model.task_to_domain) > 0:
+            first_key = next(iter(model.task_to_domain))
+            assert first_key is not None
+            assert isinstance(model.task_to_domain[first_key], str)
+    model_dict = model.to_dict()
+    assert server_json.get("name") == model_dict.get("name")
+    assert server_json.get("version") == model_dict.get("version")
+    assert server_json.get("correlationId") == model_dict.get("correlation_id")
+    assert server_json.get("input") == model_dict.get("input")
+    assert server_json.get("taskToDomain") == model_dict.get("task_to_domain")

--- a/tests/serdesertest/test_serdeser_start_workflow_request.py
+++ b/tests/serdesertest/test_serdeser_start_workflow_request.py
@@ -1,78 +1,68 @@
-import unittest
 import json
-from conductor.client.http.models.start_workflow_request import StartWorkflowRequest, IdempotencyStrategy
+
+import pytest
+
+from conductor.client.http.models.start_workflow_request import (
+    IdempotencyStrategy,
+    StartWorkflowRequest,
+)
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestStartWorkflowRequestSerDeSer(unittest.TestCase):
-
-    def setUp(self):
-        # Load JSON template string
-        self.server_json_str = JsonTemplateResolver.get_json_string("StartWorkflowRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_deserialize_serialize_start_workflow_request(self):
-        # 1. Deserialize JSON into model object
-        workflow_request = StartWorkflowRequest(
-            name=self.server_json.get('name'),
-            version=self.server_json.get('version'),
-            correlation_id=self.server_json.get('correlationId'),
-            input=self.server_json.get('input'),
-            task_to_domain=self.server_json.get('taskToDomain'),
-            workflow_def=self.server_json.get('workflowDef'),
-            external_input_payload_storage_path=self.server_json.get('externalInputPayloadStoragePath'),
-            priority=self.server_json.get('priority'),
-            created_by=self.server_json.get('createdBy'),
-            idempotency_key=self.server_json.get('idempotencyKey'),
-            idempotency_strategy=IdempotencyStrategy(self.server_json.get('idempotencyStrategy', 'FAIL'))
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get('name'), workflow_request.name)
-        self.assertEqual(self.server_json.get('version'), workflow_request.version)
-        self.assertEqual(self.server_json.get('correlationId'), workflow_request.correlation_id)
-
-        # Verify dictionaries (maps)
-        self.assertEqual(self.server_json.get('input'), workflow_request.input)
-        self.assertEqual(self.server_json.get('taskToDomain'), workflow_request.task_to_domain)
-
-        # Verify complex object
-        self.assertEqual(self.server_json.get('workflowDef'), workflow_request.workflow_def)
-
-        # Verify other fields
-        self.assertEqual(self.server_json.get('externalInputPayloadStoragePath'),
-                         workflow_request.external_input_payload_storage_path)
-        self.assertEqual(self.server_json.get('priority'), workflow_request.priority)
-        self.assertEqual(self.server_json.get('createdBy'), workflow_request.created_by)
-
-        # Verify enum field
-        self.assertEqual(self.server_json.get('idempotencyKey'), workflow_request.idempotency_key)
-        expected_strategy = IdempotencyStrategy(self.server_json.get('idempotencyStrategy', 'FAIL'))
-        self.assertEqual(expected_strategy, workflow_request.idempotency_strategy)
-
-        # 3. Serialize model back to dictionary
-        result_dict = workflow_request.to_dict()
-
-        # 4. Verify the result matches the original JSON
-        # Handle camelCase to snake_case transformations
-        self.assertEqual(self.server_json.get('name'), result_dict.get('name'))
-        self.assertEqual(self.server_json.get('version'), result_dict.get('version'))
-        self.assertEqual(self.server_json.get('correlationId'), result_dict.get('correlation_id'))
-        self.assertEqual(self.server_json.get('input'), result_dict.get('input'))
-        self.assertEqual(self.server_json.get('taskToDomain'), result_dict.get('task_to_domain'))
-        self.assertEqual(self.server_json.get('workflowDef'), result_dict.get('workflow_def'))
-        self.assertEqual(self.server_json.get('externalInputPayloadStoragePath'),
-                         result_dict.get('external_input_payload_storage_path'))
-        self.assertEqual(self.server_json.get('priority'), result_dict.get('priority'))
-        self.assertEqual(self.server_json.get('createdBy'), result_dict.get('created_by'))
-        self.assertEqual(self.server_json.get('idempotencyKey'), result_dict.get('idempotency_key'))
-
-        # For the enum, verify the string representation
-        expected_strategy_str = self.server_json.get('idempotencyStrategy', 'FAIL')
-        if isinstance(expected_strategy_str, tuple):
-            expected_strategy_str = expected_strategy_str[0]
-        self.assertEqual(expected_strategy_str, str(result_dict.get('idempotency_strategy')))
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("StartWorkflowRequest"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_deserialize_serialize_start_workflow_request(server_json):
+    workflow_request = StartWorkflowRequest(
+        name=server_json.get("name"),
+        version=server_json.get("version"),
+        correlation_id=server_json.get("correlationId"),
+        input=server_json.get("input"),
+        task_to_domain=server_json.get("taskToDomain"),
+        workflow_def=server_json.get("workflowDef"),
+        external_input_payload_storage_path=server_json.get(
+            "externalInputPayloadStoragePath"
+        ),
+        priority=server_json.get("priority"),
+        created_by=server_json.get("createdBy"),
+        idempotency_key=server_json.get("idempotencyKey"),
+        idempotency_strategy=IdempotencyStrategy(
+            server_json.get("idempotencyStrategy", "FAIL")
+        ),
+    )
+    assert server_json.get("name") == workflow_request.name
+    assert server_json.get("version") == workflow_request.version
+    assert server_json.get("correlationId") == workflow_request.correlation_id
+    assert server_json.get("input") == workflow_request.input
+    assert server_json.get("taskToDomain") == workflow_request.task_to_domain
+    assert server_json.get("workflowDef") == workflow_request.workflow_def
+    assert (
+        server_json.get("externalInputPayloadStoragePath")
+        == workflow_request.external_input_payload_storage_path
+    )
+    assert server_json.get("priority") == workflow_request.priority
+    assert server_json.get("createdBy") == workflow_request.created_by
+    assert server_json.get("idempotencyKey") == workflow_request.idempotency_key
+    expected_strategy = IdempotencyStrategy(
+        server_json.get("idempotencyStrategy", "FAIL")
+    )
+    assert expected_strategy == workflow_request.idempotency_strategy
+    result_dict = workflow_request.to_dict()
+    assert server_json.get("name") == result_dict.get("name")
+    assert server_json.get("version") == result_dict.get("version")
+    assert server_json.get("correlationId") == result_dict.get("correlation_id")
+    assert server_json.get("input") == result_dict.get("input")
+    assert server_json.get("taskToDomain") == result_dict.get("task_to_domain")
+    assert server_json.get("workflowDef") == result_dict.get("workflow_def")
+    assert server_json.get("externalInputPayloadStoragePath") == result_dict.get(
+        "external_input_payload_storage_path"
+    )
+    assert server_json.get("priority") == result_dict.get("priority")
+    assert server_json.get("createdBy") == result_dict.get("created_by")
+    assert server_json.get("idempotencyKey") == result_dict.get("idempotency_key")
+    expected_strategy_str = server_json.get("idempotencyStrategy", "FAIL")
+    if isinstance(expected_strategy_str, tuple):
+        expected_strategy_str = expected_strategy_str[0]
+    assert expected_strategy_str == str(result_dict.get("idempotency_strategy"))

--- a/tests/serdesertest/test_serdeser_state_change_event.py
+++ b/tests/serdesertest/test_serdeser_state_change_event.py
@@ -1,56 +1,38 @@
-import unittest
 import json
-from typing import Dict, List
 
-from conductor.client.http.models.state_change_event import StateChangeEvent, StateChangeConfig, StateChangeEventType
+import pytest
+
+from conductor.client.http.models.state_change_event import (
+    StateChangeConfig,
+    StateChangeEvent,
+    StateChangeEventType,
+)
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestStateChangeEventSerialization(unittest.TestCase):
-    def setUp(self):
-        # Load JSON templates
-        self.state_change_event_json_str = JsonTemplateResolver.get_json_string("StateChangeEvent")
-
-    def test_state_change_event_serde(self):
-        # 1. Deserialize JSON to SDK model
-        state_change_event_json = json.loads(self.state_change_event_json_str)
-
-        # Create model instance using constructor
-        event = StateChangeEvent(
-            type=state_change_event_json["type"],
-            payload=state_change_event_json["payload"]
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(event.type, state_change_event_json["type"])
-        self.assertEqual(event.payload, state_change_event_json["payload"])
-
-        # 3. Serialize back to JSON
-        serialized_json = event.to_dict()
-
-        # 4. Verify the resulting JSON matches the original
-        self.assertEqual(serialized_json["type"], state_change_event_json["type"])
-        self.assertEqual(serialized_json["payload"], state_change_event_json["payload"])
-
-    def test_state_change_config_multiple_event_types(self):
-        # Test with multiple event types
-        event_types = [StateChangeEventType.onStart, StateChangeEventType.onSuccess]
-        events = [
-            StateChangeEvent(type="sample_type", payload={"key": "value"})
-        ]
-
-        config = StateChangeConfig(event_type=event_types, events=events)
-
-        # Verify type field contains comma-separated event type names
-        self.assertEqual(config.type, "onStart,onSuccess")
-
-        # Serialize and verify
-        serialized_json = config.to_dict()
-        self.assertEqual(serialized_json["type"], "onStart,onSuccess")
-        self.assertEqual(len(serialized_json["events"]), 1)
-        self.assertEqual(serialized_json["events"][0]["type"], "sample_type")
-        self.assertEqual(serialized_json["events"][0]["payload"], {"key": "value"})
+@pytest.fixture
+def state_change_event_json():
+    return json.loads(JsonTemplateResolver.get_json_string("StateChangeEvent"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_state_change_event_serde(state_change_event_json):
+    event = StateChangeEvent(
+        type=state_change_event_json["type"], payload=state_change_event_json["payload"]
+    )
+    assert event.type == state_change_event_json["type"]
+    assert event.payload == state_change_event_json["payload"]
+    serialized_json = event.to_dict()
+    assert serialized_json["type"] == state_change_event_json["type"]
+    assert serialized_json["payload"] == state_change_event_json["payload"]
+
+
+def test_state_change_config_multiple_event_types():
+    event_types = [StateChangeEventType.onStart, StateChangeEventType.onSuccess]
+    events = [StateChangeEvent(type="sample_type", payload={"key": "value"})]
+    config = StateChangeConfig(event_type=event_types, events=events)
+    assert config.type == "onStart,onSuccess"
+    serialized_json = config.to_dict()
+    assert serialized_json["type"] == "onStart,onSuccess"
+    assert len(serialized_json["events"]) == 1
+    assert serialized_json["events"][0]["type"] == "sample_type"
+    assert serialized_json["events"][0]["payload"] == {"key": "value"}

--- a/tests/serdesertest/test_serdeser_sub_workflow_params.py
+++ b/tests/serdesertest/test_serdeser_sub_workflow_params.py
@@ -1,80 +1,57 @@
-import unittest
-from conductor.client.http.models.sub_workflow_params import SubWorkflowParams
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 import json
 
+import pytest
 
-class TestSubWorkflowParamsSerialization(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("SubWorkflowParams")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_serialization_deserialization(self):
-        # 1. Deserialize JSON into model object
-        model_obj = SubWorkflowParams(
-            name=self.server_json["name"],
-            version=self.server_json.get("version"),
-            task_to_domain=self.server_json.get("taskToDomain"),
-            workflow_definition=self.server_json.get("workflowDefinition"),
-            idempotency_key=self.server_json.get("idempotencyKey"),
-            idempotency_strategy=self.server_json.get("idempotencyStrategy"),
-            priority=self.server_json.get("priority")
-        )
-
-        # 2. Verify all fields are correctly populated
-        self.assertEqual(model_obj.name, self.server_json["name"])
-
-        if "version" in self.server_json:
-            self.assertEqual(model_obj.version, self.server_json["version"])
-
-        if "taskToDomain" in self.server_json:
-            # Verify map structure
-            self.assertEqual(model_obj.task_to_domain, self.server_json["taskToDomain"])
-            # Check a specific entry if available
-            if self.server_json["taskToDomain"] and len(self.server_json["taskToDomain"]) > 0:
-                first_key = next(iter(self.server_json["taskToDomain"].keys()))
-                self.assertEqual(model_obj.task_to_domain[first_key], self.server_json["taskToDomain"][first_key])
-
-        if "workflowDefinition" in self.server_json:
-            # This would be a complex object that may need special handling
-            self.assertEqual(model_obj.workflow_definition, self.server_json["workflowDefinition"])
-
-        if "idempotencyKey" in self.server_json:
-            self.assertEqual(model_obj.idempotency_key, self.server_json["idempotencyKey"])
-
-        if "idempotencyStrategy" in self.server_json:
-            # This is likely an enum that may need special handling
-            self.assertEqual(model_obj.idempotency_strategy, self.server_json["idempotencyStrategy"])
-
-        if "priority" in self.server_json:
-            self.assertEqual(model_obj.priority, self.server_json["priority"])
-
-        # 3. Serialize model back to dictionary
-        model_dict = model_obj.to_dict()
-
-        # 4. Verify the serialized dict matches original JSON structure
-        # Check each field after transformation from snake_case back to camelCase
-        if "name" in self.server_json:
-            self.assertEqual(model_dict["name"], self.server_json["name"])
-
-        if "version" in self.server_json:
-            self.assertEqual(model_dict["version"], self.server_json["version"])
-
-        if "taskToDomain" in self.server_json:
-            self.assertEqual(model_dict["task_to_domain"], self.server_json["taskToDomain"])
-
-        if "workflowDefinition" in self.server_json:
-            self.assertEqual(model_dict["workflow_definition"], self.server_json["workflowDefinition"])
-
-        if "idempotencyKey" in self.server_json:
-            self.assertEqual(model_dict["idempotency_key"], self.server_json["idempotencyKey"])
-
-        if "idempotencyStrategy" in self.server_json:
-            self.assertEqual(model_dict["idempotency_strategy"], self.server_json["idempotencyStrategy"])
-
-        if "priority" in self.server_json:
-            self.assertEqual(model_dict["priority"], self.server_json["priority"])
+from conductor.client.http.models.sub_workflow_params import SubWorkflowParams
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-if __name__ == "__main__":
-    unittest.main()
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("SubWorkflowParams"))
+
+
+def test_serialization_deserialization(server_json):
+    model_obj = SubWorkflowParams(
+        name=server_json["name"],
+        version=server_json.get("version"),
+        task_to_domain=server_json.get("taskToDomain"),
+        workflow_definition=server_json.get("workflowDefinition"),
+        idempotency_key=server_json.get("idempotencyKey"),
+        idempotency_strategy=server_json.get("idempotencyStrategy"),
+        priority=server_json.get("priority"),
+    )
+    assert model_obj.name == server_json["name"]
+    if "version" in server_json:
+        assert model_obj.version == server_json["version"]
+    if "taskToDomain" in server_json:
+        assert model_obj.task_to_domain == server_json["taskToDomain"]
+        if server_json["taskToDomain"] and len(server_json["taskToDomain"]) > 0:
+            first_key = next(iter(server_json["taskToDomain"].keys()))
+            assert (
+                model_obj.task_to_domain[first_key]
+                == server_json["taskToDomain"][first_key]
+            )
+    if "workflowDefinition" in server_json:
+        assert model_obj.workflow_definition == server_json["workflowDefinition"]
+    if "idempotencyKey" in server_json:
+        assert model_obj.idempotency_key == server_json["idempotencyKey"]
+    if "idempotencyStrategy" in server_json:
+        assert model_obj.idempotency_strategy == server_json["idempotencyStrategy"]
+    if "priority" in server_json:
+        assert model_obj.priority == server_json["priority"]
+    model_dict = model_obj.to_dict()
+    if "name" in server_json:
+        assert model_dict["name"] == server_json["name"]
+    if "version" in server_json:
+        assert model_dict["version"] == server_json["version"]
+    if "taskToDomain" in server_json:
+        assert model_dict["task_to_domain"] == server_json["taskToDomain"]
+    if "workflowDefinition" in server_json:
+        assert model_dict["workflow_definition"] == server_json["workflowDefinition"]
+    if "idempotencyKey" in server_json:
+        assert model_dict["idempotency_key"] == server_json["idempotencyKey"]
+    if "idempotencyStrategy" in server_json:
+        assert model_dict["idempotency_strategy"] == server_json["idempotencyStrategy"]
+    if "priority" in server_json:
+        assert model_dict["priority"] == server_json["priority"]

--- a/tests/serdesertest/test_serdeser_subject_ref.py
+++ b/tests/serdesertest/test_serdeser_subject_ref.py
@@ -1,42 +1,31 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.subject_ref import SubjectRef
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestSubjectRefSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template for SubjectRef
-        self.server_json_str = JsonTemplateResolver.get_json_string("SubjectRef")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_subject_ref_serdes(self):
-        # 1. Deserialize server JSON into SDK model object
-        subject_ref = SubjectRef(
-            type=self.server_json.get("type"),
-            id=self.server_json.get("id")
-        )
-
-        # 2. Verify all fields are properly populated during deserialization
-        self.assertEqual(subject_ref.type, self.server_json.get("type"))
-        self.assertEqual(subject_ref.id, self.server_json.get("id"))
-
-        # Check type is a valid enum value
-        self.assertIn(subject_ref.type, ["USER", "ROLE", "GROUP"])
-
-        # 3. Serialize the SDK model back to JSON
-        serialized_json = subject_ref.to_dict()
-
-        # 4. Verify the resulting JSON matches the original
-        self.assertEqual(serialized_json["type"], self.server_json.get("type"))
-        self.assertEqual(serialized_json["id"], self.server_json.get("id"))
-
-        # Convert both to strings to compare the complete structure
-        original_json_str = json.dumps(self.server_json, sort_keys=True)
-        serialized_json_str = json.dumps(serialized_json, sort_keys=True)
-
-        self.assertEqual(serialized_json_str, original_json_str)
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("SubjectRef")
+    return json.loads(server_json_str)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_subject_ref_serdes(server_json):
+    # 1. Deserialize server JSON into SDK model object
+    subject_ref = SubjectRef(type=server_json.get("type"), id=server_json.get("id"))
+    # 2. Verify all fields are properly populated during deserialization
+    assert subject_ref.type == server_json.get("type")
+    assert subject_ref.id == server_json.get("id")
+    # Check type is a valid enum value
+    assert subject_ref.type in ["USER", "ROLE", "GROUP"]
+    # 3. Serialize the SDK model back to JSON
+    serialized_json = subject_ref.to_dict()
+    # 4. Verify the resulting JSON matches the original
+    assert serialized_json["type"] == server_json.get("type")
+    assert serialized_json["id"] == server_json.get("id")
+    # Convert both to strings to compare the complete structure
+    original_json_str = json.dumps(server_json, sort_keys=True)
+    serialized_json_str = json.dumps(serialized_json, sort_keys=True)
+    assert serialized_json_str == original_json_str

--- a/tests/serdesertest/test_serdeser_tag_object.py
+++ b/tests/serdesertest/test_serdeser_tag_object.py
@@ -1,53 +1,48 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.tag_object import TagObject, TypeEnum
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestTagObjectSerDeser(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("Tag")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_tag_object_ser_deser(self):
-        # 1. Deserialize JSON to model
-        tag_object = TagObject(
-            key=self.server_json.get("key"),
-            type=self.server_json.get("type"),
-            value=self.server_json.get("value")
-        )
-
-        # 2. Verify fields are properly populated
-        self.assertEqual(tag_object.key, self.server_json.get("key"), "Key field not correctly deserialized")
-        self.assertEqual(tag_object.type, self.server_json.get("type"), "Type field not correctly deserialized")
-        self.assertEqual(tag_object.value, self.server_json.get("value"), "Value field not correctly deserialized")
-
-        # Verify enum values if applicable
-        if tag_object.type:
-            self.assertIn(tag_object.type, [TypeEnum.METADATA.value, TypeEnum.RATE_LIMIT.value],
-                          "Type field not correctly mapped to enum")
-
-        # 3. Serialize model back to dictionary
-        result_dict = tag_object.to_dict()
-
-        # Convert keys from snake_case to camelCase if needed
-        # For TagObject, the attribute_map shows no transformation is needed
-
-        # 4. Verify serialized JSON matches original
-        self.assertEqual(result_dict.get("key"), self.server_json.get("key"),
-                         "Key field not correctly serialized")
-        self.assertEqual(result_dict.get("type"), self.server_json.get("type"),
-                         "Type field not correctly serialized")
-        self.assertEqual(result_dict.get("value"), self.server_json.get("value"),
-                         "Value field not correctly serialized")
-
-        # Verify overall structure matches
-        for key in self.server_json:
-            self.assertIn(key, result_dict, f"Field {key} missing from serialized output")
-            self.assertEqual(result_dict[key], self.server_json[key],
-                             f"Field {key} has different value in serialized output")
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("Tag"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_tag_object_ser_deser(server_json):
+    tag_object = TagObject(
+        key=server_json.get("key"),
+        type=server_json.get("type"),
+        value=server_json.get("value"),
+    )
+    assert tag_object.key == server_json.get(
+        "key"
+    ), "Key field not correctly deserialized"
+    assert tag_object.type == server_json.get(
+        "type"
+    ), "Type field not correctly deserialized"
+    assert tag_object.value == server_json.get(
+        "value"
+    ), "Value field not correctly deserialized"
+    if tag_object.type:
+        assert tag_object.type in [
+            TypeEnum.METADATA.value,
+            TypeEnum.RATE_LIMIT.value,
+        ], "Type field not correctly mapped to enum"
+    result_dict = tag_object.to_dict()
+    assert result_dict.get("key") == server_json.get(
+        "key"
+    ), "Key field not correctly serialized"
+    assert result_dict.get("type") == server_json.get(
+        "type"
+    ), "Type field not correctly serialized"
+    assert result_dict.get("value") == server_json.get(
+        "value"
+    ), "Value field not correctly serialized"
+    for key in server_json:
+        assert key in result_dict, f"Field {key} missing from serialized output"
+        assert (
+            result_dict[key] == server_json[key]
+        ), f"Field {key} has different value in serialized output"

--- a/tests/serdesertest/test_serdeser_tag_string.py
+++ b/tests/serdesertest/test_serdeser_tag_string.py
@@ -1,54 +1,44 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.tag_string import TagString, TypeEnum
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestTagStringSerialization(unittest.TestCase):
-
-    def setUp(self):
-        # Load the JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("Tag")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_tag_string_serde(self):
-        """Test serialization and deserialization of TagString model"""
-
-        # 1. Deserialize JSON into model object
-        tag_string = TagString(
-            key=self.server_json.get('key'),
-            type=self.server_json.get('type'),
-            value=self.server_json.get('value')
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get('key'), tag_string.key)
-        self.assertEqual(self.server_json.get('type'), tag_string.type)
-        self.assertEqual(self.server_json.get('value'), tag_string.value)
-
-        # Specific enum validation if 'type' is present
-        if self.server_json.get('type'):
-            self.assertIn(tag_string.type, [TypeEnum.METADATA.value, TypeEnum.RATE_LIMIT.value])
-
-        # 3. Serialize model back to JSON
-        model_dict = tag_string.to_dict()
-        model_json = json.dumps(model_dict)
-        model_dict_reloaded = json.loads(model_json)
-
-        # 4. Verify JSON matches the original
-        # Note: Only compare fields that were in the original JSON
-        for key in self.server_json:
-            self.assertEqual(self.server_json[key], model_dict_reloaded[key])
-
-        # Create another instance using the dict and verify equality
-        reconstructed_tag = TagString(
-            key=model_dict_reloaded.get('key'),
-            type=model_dict_reloaded.get('type'),
-            value=model_dict_reloaded.get('value')
-        )
-
-        self.assertEqual(tag_string, reconstructed_tag)
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("Tag")
+    return json.loads(server_json_str)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_tag_string_serde(server_json):
+    """Test serialization and deserialization of TagString model"""
+    # 1. Deserialize JSON into model object
+    tag_string = TagString(
+        key=server_json.get("key"),
+        type=server_json.get("type"),
+        value=server_json.get("value"),
+    )
+    # 2. Verify all fields are properly populated
+    assert server_json.get("key") == tag_string.key
+    assert server_json.get("type") == tag_string.type
+    assert server_json.get("value") == tag_string.value
+    # Specific enum validation if 'type' is present
+    if server_json.get("type"):
+        assert tag_string.type in [TypeEnum.METADATA.value, TypeEnum.RATE_LIMIT.value]
+    # 3. Serialize model back to JSON
+    model_dict = tag_string.to_dict()
+    model_json = json.dumps(model_dict)
+    model_dict_reloaded = json.loads(model_json)
+    # 4. Verify JSON matches the original
+    # Note: Only compare fields that were in the original JSON
+    for key in server_json:
+        assert server_json[key] == model_dict_reloaded[key]
+    # Create another instance using the dict and verify equality
+    reconstructed_tag = TagString(
+        key=model_dict_reloaded.get("key"),
+        type=model_dict_reloaded.get("type"),
+        value=model_dict_reloaded.get("value"),
+    )
+    assert tag_string == reconstructed_tag

--- a/tests/serdesertest/test_serdeser_target_ref.py
+++ b/tests/serdesertest/test_serdeser_target_ref.py
@@ -1,53 +1,38 @@
-import unittest
 import json
-from conductor.client.http.models.target_ref import TargetRef, TargetType
+
+import pytest
+
+from conductor.client.http.models.target_ref import TargetRef
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestTargetRefSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("TargetRef")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_target_ref_serdes(self):
-        # 1. Deserialize server JSON into SDK model object
-        target_ref = TargetRef(
-            type=self.server_json.get('type'),
-            id=self.server_json.get('id')
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertIsNotNone(target_ref.type)
-        self.assertIsNotNone(target_ref.id)
-
-        # Verify type is a valid enum value
-        valid_types = ["WORKFLOW_DEF", "TASK_DEF", "APPLICATION",
-                       "USER", "SECRET_NAME", "TAG", "DOMAIN"]
-        self.assertIn(target_ref.type, valid_types)
-
-        # 3. Serialize SDK model back to JSON
-        sdk_json = target_ref.to_dict()
-
-        # 4. Verify the resulting JSON matches the original
-        self.assertEqual(self.server_json.get('type'), sdk_json.get('type'))
-        self.assertEqual(self.server_json.get('id'), sdk_json.get('id'))
-
-        # Additional check: Complete round trip by deserializing again
-        serialized_json = json.dumps(sdk_json)
-        deserialized_json = json.loads(serialized_json)
-        round_trip_obj = TargetRef(
-            type=deserialized_json.get('type'),
-            id=deserialized_json.get('id')
-        )
-
-        # Verify round trip object matches original
-        self.assertEqual(target_ref.type, round_trip_obj.type)
-        self.assertEqual(target_ref.id, round_trip_obj.id)
-
-        # Verify equality method works correctly
-        self.assertEqual(target_ref, round_trip_obj)
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("TargetRef"))
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_target_ref_serdes(server_json):
+    target_ref = TargetRef(type=server_json.get("type"), id=server_json.get("id"))
+    assert target_ref.type is not None
+    assert target_ref.id is not None
+    valid_types = [
+        "WORKFLOW_DEF",
+        "TASK_DEF",
+        "APPLICATION",
+        "USER",
+        "SECRET_NAME",
+        "TAG",
+        "DOMAIN",
+    ]
+    assert target_ref.type in valid_types
+    sdk_json = target_ref.to_dict()
+    assert server_json.get("type") == sdk_json.get("type")
+    assert server_json.get("id") == sdk_json.get("id")
+    serialized_json = json.dumps(sdk_json)
+    deserialized_json = json.loads(serialized_json)
+    round_trip_obj = TargetRef(
+        type=deserialized_json.get("type"), id=deserialized_json.get("id")
+    )
+    assert target_ref.type == round_trip_obj.type
+    assert target_ref.id == round_trip_obj.id
+    assert target_ref == round_trip_obj

--- a/tests/serdesertest/test_serdeser_task.py
+++ b/tests/serdesertest/test_serdeser_task.py
@@ -1,97 +1,68 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.task import Task
 from conductor.client.http.models.task_result_status import TaskResultStatus
-from conductor.client.http.models.workflow_task import WorkflowTask
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TaskSerDeserTest(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template for Task
-        self.server_json_str = JsonTemplateResolver.get_json_string("Task")
-        self.server_json = json.loads(self.server_json_str)
-
-        # Convert camelCase keys to snake_case for constructor
-        self.python_json = self._convert_to_snake_case(self.server_json)
-        self.maxDiff = None  # Show full diff for debugging
-
-    def test_task_serialization_deserialization(self):
-        # Step 1: Deserialize JSON to Task object
-        task = Task(**self.python_json)
-
-        # Step 2: Skip the detailed field verification since nested objects will have different field names
-        # and directly test that the Task object was created successfully
-        self.assertIsInstance(task, Task)
-
-        # Test a few key fields to ensure basic deserialization is working
-        if 'task_id' in self.python_json:
-            self.assertEqual(task.task_id, self.python_json['task_id'])
-        if 'status' in self.python_json:
-            self.assertEqual(task.status, self.python_json['status'])
-
-        # Step 3: Serialize Task object back to JSON
-        serialized_json = task.to_dict()
-
-        # Step 4: Validate that serialized JSON can be used to create another Task object
-        task2 = Task(**self._convert_to_snake_case(serialized_json))
-        self.assertIsInstance(task2, Task)
-
-        # Additional test: Verify the task_result method works correctly
-        task_result = task.to_task_result(TaskResultStatus.COMPLETED)
-        self.assertEqual(task_result.task_id, task.task_id)
-        self.assertEqual(task_result.workflow_instance_id, task.workflow_instance_id)
-        self.assertEqual(task_result.worker_id, task.worker_id)
-        self.assertEqual(task_result.status, TaskResultStatus.COMPLETED)
-
-        # Validate that the major functional fields were preserved in serialization/deserialization
-        self._validate_functional_equivalence(task, task2)
-
-    def _convert_to_snake_case(self, json_obj):
-        """Convert camelCase keys to snake_case using Task.attribute_map"""
-        if isinstance(json_obj, dict):
-            python_obj = {}
-            for key, value in json_obj.items():
-                # Find corresponding snake_case key
-                snake_key = None
-                for python_key, json_key in Task.attribute_map.items():
-                    if json_key == key:
-                        snake_key = python_key
-                        break
-
-                # If not found, keep the original key
-                if snake_key is None:
-                    snake_key = key
-
-                # Convert nested objects
-                if isinstance(value, dict) or isinstance(value, list):
-                    python_obj[snake_key] = self._convert_to_snake_case(value)
-                else:
-                    python_obj[snake_key] = value
-            return python_obj
-        elif isinstance(json_obj, list):
-            return [self._convert_to_snake_case(item) if isinstance(item, (dict, list)) else item for item in json_obj]
-        else:
-            return json_obj
-
-    def _validate_functional_equivalence(self, task1, task2):
-        """Validate that two Task objects are functionally equivalent"""
-        # Test simple fields
-        self.assertEqual(task1.task_id, task2.task_id)
-        self.assertEqual(task1.status, task2.status)
-        self.assertEqual(task1.task_type, task2.task_type)
-        self.assertEqual(task1.reference_task_name, task2.reference_task_name)
-
-        # Test that both tasks serialize to equivalent structures
-        # This is a more forgiving comparison than direct object equality
-        task1_dict = task1.to_dict()
-        task2_dict = task2.to_dict()
-
-        # Compare top-level fields that should match exactly
-        for field in ['taskId', 'status', 'taskType', 'referenceTaskName']:
-            if field in task1_dict and field in task2_dict:
-                self.assertEqual(task1_dict[field], task2_dict[field])
+def convert_to_snake_case(json_obj):
+    if isinstance(json_obj, dict):
+        python_obj = {}
+        for key, value in json_obj.items():
+            snake_key = None
+            for python_key, json_key in Task.attribute_map.items():
+                if json_key == key:
+                    snake_key = python_key
+                    break
+            if snake_key is None:
+                snake_key = key
+            if isinstance(value, dict) or isinstance(value, list):
+                python_obj[snake_key] = convert_to_snake_case(value)
+            else:
+                python_obj[snake_key] = value
+        return python_obj
+    elif isinstance(json_obj, list):
+        return [
+            convert_to_snake_case(item) if isinstance(item, (dict, list)) else item
+            for item in json_obj
+        ]
+    else:
+        return json_obj
 
 
-if __name__ == '__main__':
-    unittest.main()
+def validate_functional_equivalence(task1, task2):
+    assert task1.task_id == task2.task_id
+    assert task1.status == task2.status
+    assert task1.task_type == task2.task_type
+    assert task1.reference_task_name == task2.reference_task_name
+    task1_dict = task1.to_dict()
+    task2_dict = task2.to_dict()
+    for field in ["taskId", "status", "taskType", "referenceTaskName"]:
+        if field in task1_dict and field in task2_dict:
+            assert task1_dict[field] == task2_dict[field]
+
+
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("Task"))
+
+
+def test_task_serialization_deserialization(server_json):
+    python_json = convert_to_snake_case(server_json)
+    task = Task(**python_json)
+    assert isinstance(task, Task)
+    if "task_id" in python_json:
+        assert task.task_id == python_json["task_id"]
+    if "status" in python_json:
+        assert task.status == python_json["status"]
+    serialized_json = task.to_dict()
+    task2 = Task(**convert_to_snake_case(serialized_json))
+    assert isinstance(task2, Task)
+    task_result = task.to_task_result(TaskResultStatus.COMPLETED)
+    assert task_result.task_id == task.task_id
+    assert task_result.workflow_instance_id == task.workflow_instance_id
+    assert task_result.worker_id == task.worker_id
+    assert task_result.status == TaskResultStatus.COMPLETED
+    validate_functional_equivalence(task, task2)

--- a/tests/serdesertest/test_serdeser_task_def.py
+++ b/tests/serdesertest/test_serdeser_task_def.py
@@ -1,215 +1,166 @@
-import unittest
 import json
-from conductor.client.http.models.task_def import TaskDef
+
+import pytest
+
 from conductor.client.http.models.schema_def import SchemaDef
+from conductor.client.http.models.task_def import TaskDef
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestTaskDefSerDes(unittest.TestCase):
-    """Test serialization and deserialization of TaskDef model."""
-
-    def setUp(self):
-        """Set up test fixtures."""
-        self.server_json_str = JsonTemplateResolver.get_json_string("TaskDef")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_task_def_serdes(self):
-        """Test serialization and deserialization of TaskDef model."""
-        # 1. Server JSON can be correctly deserialized into SDK model object
-        task_def = self._create_task_def_from_json(self.server_json)
-
-        # 2. All fields are properly populated during deserialization
-        self._verify_task_def_fields(task_def, self.server_json)
-
-        # 3. The SDK model can be serialized back to JSON
-        result_json = task_def.to_dict()
-
-        # 4. The resulting JSON matches the original
-        self._compare_json_objects(self.server_json, result_json)
-
-    def _create_task_def_from_json(self, json_dict):
-        """Create TaskDef object from JSON dictionary."""
-        # Extract fields from JSON for constructor
-        owner_app = json_dict.get('ownerApp')
-        create_time = json_dict.get('createTime')
-        update_time = json_dict.get('updateTime')
-        created_by = json_dict.get('createdBy')
-        updated_by = json_dict.get('updatedBy')
-        name = json_dict.get('name')
-        description = json_dict.get('description')
-        retry_count = json_dict.get('retryCount')
-        timeout_seconds = json_dict.get('timeoutSeconds')
-        input_keys = json_dict.get('inputKeys')
-        output_keys = json_dict.get('outputKeys')
-        timeout_policy = json_dict.get('timeoutPolicy')
-        retry_logic = json_dict.get('retryLogic')
-        retry_delay_seconds = json_dict.get('retryDelaySeconds')
-        response_timeout_seconds = json_dict.get('responseTimeoutSeconds')
-        concurrent_exec_limit = json_dict.get('concurrentExecLimit')
-        input_template = json_dict.get('inputTemplate')
-        rate_limit_per_frequency = json_dict.get('rateLimitPerFrequency')
-        rate_limit_frequency_in_seconds = json_dict.get('rateLimitFrequencyInSeconds')
-        isolation_group_id = json_dict.get('isolationGroupId')
-        execution_name_space = json_dict.get('executionNameSpace')
-        owner_email = json_dict.get('ownerEmail')
-        poll_timeout_seconds = json_dict.get('pollTimeoutSeconds')
-        backoff_scale_factor = json_dict.get('backoffScaleFactor')
-
-        # Handle nested objects
-        input_schema_json = json_dict.get('inputSchema')
-        input_schema_obj = None
-        if input_schema_json:
-            input_schema_obj = SchemaDef(
-                name=input_schema_json.get('name'),
-                version=input_schema_json.get('version'),
-                type=input_schema_json.get('type'),
-                data=input_schema_json.get('data')
-            )
-
-        output_schema_json = json_dict.get('outputSchema')
-        output_schema_obj = None
-        if output_schema_json:
-            output_schema_obj = SchemaDef(
-                name=output_schema_json.get('name'),
-                version=output_schema_json.get('version'),
-                type=output_schema_json.get('type'),
-                data=output_schema_json.get('data')
-            )
-
-        enforce_schema = json_dict.get('enforceSchema', False)
-        base_type = json_dict.get('baseType')
-        total_timeout_seconds = json_dict.get('totalTimeoutSeconds')
-
-        # Create TaskDef object using constructor
-        return TaskDef(
-            owner_app=owner_app,
-            create_time=create_time,
-            update_time=update_time,
-            created_by=created_by,
-            updated_by=updated_by,
-            name=name,
-            description=description,
-            retry_count=retry_count,
-            timeout_seconds=timeout_seconds,
-            input_keys=input_keys,
-            output_keys=output_keys,
-            timeout_policy=timeout_policy,
-            retry_logic=retry_logic,
-            retry_delay_seconds=retry_delay_seconds,
-            response_timeout_seconds=response_timeout_seconds,
-            concurrent_exec_limit=concurrent_exec_limit,
-            input_template=input_template,
-            rate_limit_per_frequency=rate_limit_per_frequency,
-            rate_limit_frequency_in_seconds=rate_limit_frequency_in_seconds,
-            isolation_group_id=isolation_group_id,
-            execution_name_space=execution_name_space,
-            owner_email=owner_email,
-            poll_timeout_seconds=poll_timeout_seconds,
-            backoff_scale_factor=backoff_scale_factor,
-            input_schema=input_schema_obj,
-            output_schema=output_schema_obj,
-            enforce_schema=enforce_schema,
-            base_type=base_type,
-            total_timeout_seconds=total_timeout_seconds
+def create_task_def_from_json(json_dict):
+    owner_app = json_dict.get("ownerApp")
+    create_time = json_dict.get("createTime")
+    update_time = json_dict.get("updateTime")
+    created_by = json_dict.get("createdBy")
+    updated_by = json_dict.get("updatedBy")
+    name = json_dict.get("name")
+    description = json_dict.get("description")
+    retry_count = json_dict.get("retryCount")
+    timeout_seconds = json_dict.get("timeoutSeconds")
+    input_keys = json_dict.get("inputKeys")
+    output_keys = json_dict.get("outputKeys")
+    timeout_policy = json_dict.get("timeoutPolicy")
+    retry_logic = json_dict.get("retryLogic")
+    retry_delay_seconds = json_dict.get("retryDelaySeconds")
+    response_timeout_seconds = json_dict.get("responseTimeoutSeconds")
+    concurrent_exec_limit = json_dict.get("concurrentExecLimit")
+    input_template = json_dict.get("inputTemplate")
+    rate_limit_per_frequency = json_dict.get("rateLimitPerFrequency")
+    rate_limit_frequency_in_seconds = json_dict.get("rateLimitFrequencyInSeconds")
+    isolation_group_id = json_dict.get("isolationGroupId")
+    execution_name_space = json_dict.get("executionNameSpace")
+    owner_email = json_dict.get("ownerEmail")
+    poll_timeout_seconds = json_dict.get("pollTimeoutSeconds")
+    backoff_scale_factor = json_dict.get("backoffScaleFactor")
+    input_schema_json = json_dict.get("inputSchema")
+    input_schema_obj = None
+    if input_schema_json:
+        input_schema_obj = SchemaDef(
+            name=input_schema_json.get("name"),
+            version=input_schema_json.get("version"),
+            type=input_schema_json.get("type"),
+            data=input_schema_json.get("data"),
         )
-
-    def _verify_task_def_fields(self, task_def, json_dict):
-        """Verify all fields in TaskDef are properly populated."""
-        # Verify basic fields
-        self.assertEqual(task_def.owner_app, json_dict.get('ownerApp'))
-        self.assertEqual(task_def.create_time, json_dict.get('createTime'))
-        self.assertEqual(task_def.update_time, json_dict.get('updateTime'))
-        self.assertEqual(task_def.created_by, json_dict.get('createdBy'))
-        self.assertEqual(task_def.updated_by, json_dict.get('updatedBy'))
-        self.assertEqual(task_def.name, json_dict.get('name'))
-        self.assertEqual(task_def.description, json_dict.get('description'))
-        self.assertEqual(task_def.retry_count, json_dict.get('retryCount'))
-        self.assertEqual(task_def.timeout_seconds, json_dict.get('timeoutSeconds'))
-
-        # Verify lists
-        if json_dict.get('inputKeys'):
-            self.assertEqual(task_def.input_keys, json_dict.get('inputKeys'))
-        if json_dict.get('outputKeys'):
-            self.assertEqual(task_def.output_keys, json_dict.get('outputKeys'))
-
-        # Verify enums
-        self.assertEqual(task_def.timeout_policy, json_dict.get('timeoutPolicy'))
-        self.assertEqual(task_def.retry_logic, json_dict.get('retryLogic'))
-
-        # Verify remaining fields
-        self.assertEqual(task_def.retry_delay_seconds, json_dict.get('retryDelaySeconds'))
-        self.assertEqual(task_def.response_timeout_seconds, json_dict.get('responseTimeoutSeconds'))
-        self.assertEqual(task_def.concurrent_exec_limit, json_dict.get('concurrentExecLimit'))
-
-        # Verify complex structures
-        if json_dict.get('inputTemplate'):
-            self.assertEqual(task_def.input_template, json_dict.get('inputTemplate'))
-
-        self.assertEqual(task_def.rate_limit_per_frequency, json_dict.get('rateLimitPerFrequency'))
-        self.assertEqual(task_def.rate_limit_frequency_in_seconds, json_dict.get('rateLimitFrequencyInSeconds'))
-        self.assertEqual(task_def.isolation_group_id, json_dict.get('isolationGroupId'))
-        self.assertEqual(task_def.execution_name_space, json_dict.get('executionNameSpace'))
-        self.assertEqual(task_def.owner_email, json_dict.get('ownerEmail'))
-        self.assertEqual(task_def.poll_timeout_seconds, json_dict.get('pollTimeoutSeconds'))
-        self.assertEqual(task_def.backoff_scale_factor, json_dict.get('backoffScaleFactor'))
-
-        # Verify schema objects
-        if json_dict.get('inputSchema'):
-            self.assertIsNotNone(task_def.input_schema)
-            # Verify schema fields if needed
-            input_schema_json = json_dict.get('inputSchema')
-            self.assertEqual(task_def.input_schema.name, input_schema_json.get('name'))
-            self.assertEqual(task_def.input_schema.type, input_schema_json.get('type'))
-
-        if json_dict.get('outputSchema'):
-            self.assertIsNotNone(task_def.output_schema)
-            # Verify schema fields if needed
-            output_schema_json = json_dict.get('outputSchema')
-            self.assertEqual(task_def.output_schema.name, output_schema_json.get('name'))
-            self.assertEqual(task_def.output_schema.type, output_schema_json.get('type'))
-
-        self.assertEqual(task_def.enforce_schema, json_dict.get('enforceSchema', False))
-        self.assertEqual(task_def.base_type, json_dict.get('baseType'))
-        self.assertEqual(task_def.total_timeout_seconds, json_dict.get('totalTimeoutSeconds'))
-
-    def _compare_json_objects(self, original, result):
-        """Compare original and resulting JSON objects."""
-        # Build a mapping from camelCase to snake_case for verification
-        key_mapping = {}
-        for attr, json_key in TaskDef.attribute_map.items():
-            key_mapping[json_key] = attr
-
-        # Check each field in the original JSON
-        for camel_key, orig_value in original.items():
-            # Skip if this key is not in the mapping
-            if camel_key not in key_mapping:
-                continue
-
-            snake_key = key_mapping[camel_key]
-            result_value = result.get(snake_key)
-
-            # Handle special cases for nested objects
-            if camel_key in ['inputSchema', 'outputSchema']:
-                if orig_value is not None:
-                    self.assertIsNotNone(result_value, f"Expected {snake_key} to be present in result")
-                    # For schema objects, verify key properties
-                    if orig_value and result_value:
-                        self.assertEqual(orig_value.get('name'), result_value.get('name'))
-                        self.assertEqual(orig_value.get('type'), result_value.get('type'))
-                continue
-
-            # For lists and complex objects, check existence and content
-            if isinstance(orig_value, list):
-                self.assertEqual(orig_value, result_value, f"List {camel_key} doesn't match")
-            elif isinstance(orig_value, dict):
-                if orig_value:
-                    self.assertIsNotNone(result_value, f"Expected dict {snake_key} to be present in result")
-                    # Check dict contents if needed
-            else:
-                # For simple values, verify equality
-                self.assertEqual(orig_value, result_value,
-                                 f"Field {camel_key} (as {snake_key}) doesn't match: {orig_value} != {result_value}")
+    output_schema_json = json_dict.get("outputSchema")
+    output_schema_obj = None
+    if output_schema_json:
+        output_schema_obj = SchemaDef(
+            name=output_schema_json.get("name"),
+            version=output_schema_json.get("version"),
+            type=output_schema_json.get("type"),
+            data=output_schema_json.get("data"),
+        )
+    enforce_schema = json_dict.get("enforceSchema", False)
+    base_type = json_dict.get("baseType")
+    total_timeout_seconds = json_dict.get("totalTimeoutSeconds")
+    return TaskDef(
+        owner_app=owner_app,
+        create_time=create_time,
+        update_time=update_time,
+        created_by=created_by,
+        updated_by=updated_by,
+        name=name,
+        description=description,
+        retry_count=retry_count,
+        timeout_seconds=timeout_seconds,
+        input_keys=input_keys,
+        output_keys=output_keys,
+        timeout_policy=timeout_policy,
+        retry_logic=retry_logic,
+        retry_delay_seconds=retry_delay_seconds,
+        response_timeout_seconds=response_timeout_seconds,
+        concurrent_exec_limit=concurrent_exec_limit,
+        input_template=input_template,
+        rate_limit_per_frequency=rate_limit_per_frequency,
+        rate_limit_frequency_in_seconds=rate_limit_frequency_in_seconds,
+        isolation_group_id=isolation_group_id,
+        execution_name_space=execution_name_space,
+        owner_email=owner_email,
+        poll_timeout_seconds=poll_timeout_seconds,
+        backoff_scale_factor=backoff_scale_factor,
+        input_schema=input_schema_obj,
+        output_schema=output_schema_obj,
+        enforce_schema=enforce_schema,
+        base_type=base_type,
+        total_timeout_seconds=total_timeout_seconds,
+    )
 
 
-if __name__ == '__main__':
-    unittest.main()
+def verify_task_def_fields(task_def, json_dict):
+    assert task_def.owner_app == json_dict.get("ownerApp")
+    assert task_def.create_time == json_dict.get("createTime")
+    assert task_def.update_time == json_dict.get("updateTime")
+    assert task_def.created_by == json_dict.get("createdBy")
+    assert task_def.updated_by == json_dict.get("updatedBy")
+    assert task_def.name == json_dict.get("name")
+    assert task_def.description == json_dict.get("description")
+    assert task_def.retry_count == json_dict.get("retryCount")
+    assert task_def.timeout_seconds == json_dict.get("timeoutSeconds")
+    if json_dict.get("inputKeys"):
+        assert task_def.input_keys == json_dict.get("inputKeys")
+    if json_dict.get("outputKeys"):
+        assert task_def.output_keys == json_dict.get("outputKeys")
+    assert task_def.timeout_policy == json_dict.get("timeoutPolicy")
+    assert task_def.retry_logic == json_dict.get("retryLogic")
+    assert task_def.retry_delay_seconds == json_dict.get("retryDelaySeconds")
+    assert task_def.response_timeout_seconds == json_dict.get("responseTimeoutSeconds")
+    assert task_def.concurrent_exec_limit == json_dict.get("concurrentExecLimit")
+    if json_dict.get("inputTemplate"):
+        assert task_def.input_template == json_dict.get("inputTemplate")
+    assert task_def.rate_limit_per_frequency == json_dict.get("rateLimitPerFrequency")
+    assert task_def.rate_limit_frequency_in_seconds == json_dict.get(
+        "rateLimitFrequencyInSeconds"
+    )
+    assert task_def.isolation_group_id == json_dict.get("isolationGroupId")
+    assert task_def.execution_name_space == json_dict.get("executionNameSpace")
+    assert task_def.owner_email == json_dict.get("ownerEmail")
+    assert task_def.poll_timeout_seconds == json_dict.get("pollTimeoutSeconds")
+    assert task_def.backoff_scale_factor == json_dict.get("backoffScaleFactor")
+    if json_dict.get("inputSchema"):
+        assert task_def.input_schema is not None
+        input_schema_json = json_dict.get("inputSchema")
+        assert task_def.input_schema.name == input_schema_json.get("name")
+        assert task_def.input_schema.type == input_schema_json.get("type")
+    if json_dict.get("outputSchema"):
+        assert task_def.output_schema is not None
+        output_schema_json = json_dict.get("outputSchema")
+        assert task_def.output_schema.name == output_schema_json.get("name")
+        assert task_def.output_schema.type == output_schema_json.get("type")
+    assert task_def.enforce_schema == json_dict.get("enforceSchema", False)
+    assert task_def.base_type == json_dict.get("baseType")
+    assert task_def.total_timeout_seconds == json_dict.get("totalTimeoutSeconds")
+
+
+def compare_json_objects(original, result):
+    key_mapping = {json_key: attr for (attr, json_key) in TaskDef.attribute_map.items()}
+    for camel_key, orig_value in original.items():
+        if camel_key not in key_mapping:
+            continue
+        snake_key = key_mapping[camel_key]
+        result_value = result.get(snake_key)
+        if camel_key in ["inputSchema", "outputSchema"]:
+            if orig_value is not None:
+                assert result_value is not None
+                if orig_value and result_value:
+                    assert orig_value.get("name") == result_value.get("name")
+                    assert orig_value.get("type") == result_value.get("type")
+            continue
+        if isinstance(orig_value, list):
+            assert orig_value == result_value
+        elif isinstance(orig_value, dict):
+            if orig_value:
+                assert result_value is not None
+        else:
+            assert orig_value == result_value
+
+
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("TaskDef"))
+
+
+def test_task_def_serdes(server_json):
+    task_def = create_task_def_from_json(server_json)
+    verify_task_def_fields(task_def, server_json)
+    result_json = task_def.to_dict()
+    compare_json_objects(server_json, result_json)

--- a/tests/serdesertest/test_serdeser_task_details.py
+++ b/tests/serdesertest/test_serdeser_task_details.py
@@ -1,76 +1,68 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.task_details import TaskDetails
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestTaskDetailsSerialization(unittest.TestCase):
-    """Test case to validate serialization and deserialization of TaskDetails model."""
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("EventHandler.TaskDetails")
+    return json.loads(server_json_str)
 
-    def setUp(self):
-        """Set up test fixtures."""
-        self.server_json_str = JsonTemplateResolver.get_json_string("EventHandler.TaskDetails")
-        self.server_json = json.loads(self.server_json_str)
 
-    def test_task_details_serde(self):
-        """
-        Test serialization and deserialization of TaskDetails model.
-
-        This test verifies:
-        1. Server JSON can be correctly deserialized into TaskDetails object
-        2. All fields are properly populated during deserialization
-        3. The TaskDetails object can be serialized back to JSON
-        4. The resulting JSON matches the original, ensuring no data is lost
-        """
-        # 1. Deserialize JSON into TaskDetails object
-        task_details = TaskDetails(
-            workflow_id=self.server_json.get('workflowId'),
-            task_ref_name=self.server_json.get('taskRefName'),
-            output=self.server_json.get('output'),
-            task_id=self.server_json.get('taskId')
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get('workflowId'), task_details.workflow_id)
-        self.assertEqual(self.server_json.get('taskRefName'), task_details.task_ref_name)
-        self.assertEqual(self.server_json.get('output'), task_details.output)
-        self.assertEqual(self.server_json.get('taskId'), task_details.task_id)
-
-        # Test the put_output_item method
-        if task_details.output is None:
-            task_details.put_output_item("test_key", "test_value")
-            self.assertEqual({"test_key": "test_value"}, task_details.output)
-        else:
-            original_size = len(task_details.output)
-            task_details.put_output_item("test_key", "test_value")
-            self.assertEqual(original_size + 1, len(task_details.output))
-            self.assertEqual("test_value", task_details.output.get("test_key"))
-
-        # 3. Serialize TaskDetails object back to dictionary
-        task_details_dict = task_details.to_dict()
-
-        # 4. Compare the serialized dictionary with the original JSON
-        # Note: We need to handle the test_key we added separately
-        expected_dict = {
-            'workflow_id': self.server_json.get('workflowId'),
-            'task_ref_name': self.server_json.get('taskRefName'),
-            'output': self.server_json.get('output'),
-            'task_id': self.server_json.get('taskId')
+def test_task_details_serde(server_json):
+    """
+    Test serialization and deserialization of TaskDetails model.
+    This test verifies:
+    1. Server JSON can be correctly deserialized into TaskDetails object
+    2. All fields are properly populated during deserialization
+    3. The TaskDetails object can be serialized back to JSON
+    4. The resulting JSON matches the original, ensuring no data is lost
+    """
+    # 1. Deserialize JSON into TaskDetails object
+    task_details = TaskDetails(
+        workflow_id=server_json.get("workflowId"),
+        task_ref_name=server_json.get("taskRefName"),
+        output=server_json.get("output"),
+        task_id=server_json.get("taskId"),
+    )
+    # 2. Verify all fields are properly populated
+    assert server_json.get("workflowId") == task_details.workflow_id
+    assert server_json.get("taskRefName") == task_details.task_ref_name
+    assert server_json.get("output") == task_details.output
+    assert server_json.get("taskId") == task_details.task_id
+    # Test the put_output_item method
+    if task_details.output is None:
+        task_details.put_output_item("test_key", "test_value")
+        assert {"test_key": "test_value"} == task_details.output
+    else:
+        original_size = len(task_details.output)
+        task_details.put_output_item("test_key", "test_value")
+        assert original_size + 1 == len(task_details.output)
+        assert "test_value" == task_details.output.get("test_key")
+    # 3. Serialize TaskDetails object back to dictionary
+    task_details_dict = task_details.to_dict()
+    # 4. Compare the serialized dictionary with the original JSON
+    # Note: We need to handle the test_key we added separately
+    expected_dict = {
+        "workflow_id": server_json.get("workflowId"),
+        "task_ref_name": server_json.get("taskRefName"),
+        "output": server_json.get("output"),
+        "task_id": server_json.get("taskId"),
+    }
+    # If output was None in the original, it would now be {"test_key": "test_value"}
+    if expected_dict["output"] is None:
+        expected_dict["output"] = {"test_key": "test_value"}
+    else:
+        expected_dict["output"] = {
+            **expected_dict["output"],
+            "test_key": "test_value",
         }
-
-        # If output was None in the original, it would now be {"test_key": "test_value"}
-        if expected_dict['output'] is None:
-            expected_dict['output'] = {"test_key": "test_value"}
+    for key, value in expected_dict.items():
+        if key == "output":
+            for output_key, output_value in value.items():
+                assert output_value == task_details_dict[key].get(output_key)
         else:
-            expected_dict['output'] = {**expected_dict['output'], "test_key": "test_value"}
-
-        for key, value in expected_dict.items():
-            if key == 'output':
-                for output_key, output_value in value.items():
-                    self.assertEqual(output_value, task_details_dict[key].get(output_key))
-            else:
-                self.assertEqual(value, task_details_dict[key])
-
-
-if __name__ == '__main__':
-    unittest.main()
+            assert value == task_details_dict[key]

--- a/tests/serdesertest/test_serdeser_task_exec_log.py
+++ b/tests/serdesertest/test_serdeser_task_exec_log.py
@@ -1,55 +1,44 @@
-import unittest
 import json
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
+
+import pytest
+
 from conductor.client.http.models.task_exec_log import TaskExecLog
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TaskExecLogSerdeserTest(unittest.TestCase):
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("TaskExecLog")
+    return json.loads(server_json_str)
+
+
+def test_task_exec_log_serdeser(server_json):
     """
-    Test class for validating serialization/deserialization of TaskExecLog model
+    Test serialization and deserialization of TaskExecLog
     """
-
-    def setUp(self):
-        """
-        Set up test fixtures
-        """
-        self.server_json_str = JsonTemplateResolver.get_json_string("TaskExecLog")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_task_exec_log_serdeser(self):
-        """
-        Test serialization and deserialization of TaskExecLog
-        """
-        # 1. Deserialize JSON into SDK model object
-        task_exec_log = TaskExecLog(
-            log=self.server_json.get("log"),
-            task_id=self.server_json.get("taskId"),
-            created_time=self.server_json.get("createdTime")
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get("log"), task_exec_log.log)
-        self.assertEqual(self.server_json.get("taskId"), task_exec_log.task_id)
-        self.assertEqual(self.server_json.get("createdTime"), task_exec_log.created_time)
-
-        # 3. Serialize SDK model back to dictionary
-        task_exec_log_dict = task_exec_log.to_dict()
-
-        # 4. Verify serialized dictionary matches original JSON
-        # Check the original JSON attributes are in the serialized dictionary
-        self.assertEqual(self.server_json.get("log"), task_exec_log_dict.get("log"))
-        # Handle camelCase to snake_case transformations
-        self.assertEqual(self.server_json.get("taskId"), task_exec_log_dict.get("task_id"))
-        self.assertEqual(self.server_json.get("createdTime"), task_exec_log_dict.get("created_time"))
-
-        # Verify no data is lost (all keys from original JSON exist in serialized output)
-        for key in self.server_json:
-            if key == "taskId":
-                self.assertIn("task_id", task_exec_log_dict)
-            elif key == "createdTime":
-                self.assertIn("created_time", task_exec_log_dict)
-            else:
-                self.assertIn(key, task_exec_log_dict)
-
-if __name__ == '__main__':
-    unittest.main()
+    # 1. Deserialize JSON into SDK model object
+    task_exec_log = TaskExecLog(
+        log=server_json.get("log"),
+        task_id=server_json.get("taskId"),
+        created_time=server_json.get("createdTime"),
+    )
+    # 2. Verify all fields are properly populated
+    assert server_json.get("log") == task_exec_log.log
+    assert server_json.get("taskId") == task_exec_log.task_id
+    assert server_json.get("createdTime") == task_exec_log.created_time
+    # 3. Serialize SDK model back to dictionary
+    task_exec_log_dict = task_exec_log.to_dict()
+    # 4. Verify serialized dictionary matches original JSON
+    # Check the original JSON attributes are in the serialized dictionary
+    assert server_json.get("log") == task_exec_log_dict.get("log")
+    # Handle camelCase to snake_case transformations
+    assert server_json.get("taskId") == task_exec_log_dict.get("task_id")
+    assert server_json.get("createdTime") == task_exec_log_dict.get("created_time")
+    # Verify no data is lost (all keys from original JSON exist in serialized output)
+    for key in server_json:
+        if key == "taskId":
+            assert "task_id" in task_exec_log_dict
+        elif key == "createdTime":
+            assert "created_time" in task_exec_log_dict
+        else:
+            assert key in task_exec_log_dict

--- a/tests/serdesertest/test_serdeser_task_result.py
+++ b/tests/serdesertest/test_serdeser_task_result.py
@@ -1,99 +1,102 @@
-import unittest
 import json
-from conductor.client.http.models.task_result import TaskResult
+
+import pytest
+
 from conductor.client.http.models.task_exec_log import TaskExecLog
+from conductor.client.http.models.task_result import TaskResult
 from conductor.client.http.models.task_result_status import TaskResultStatus
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestTaskResultSerDeser(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("TaskResult")
+@pytest.fixture
+def server_json_str():
+    return JsonTemplateResolver.get_json_string("TaskResult")
 
-    def test_task_result_serdeser(self):
-        # Step 1: Deserialize JSON into TaskResult object
-        server_json_dict = json.loads(self.server_json_str)
-        task_result = TaskResult(
-            workflow_instance_id=server_json_dict.get("workflowInstanceId"),
-            task_id=server_json_dict.get("taskId"),
-            reason_for_incompletion=server_json_dict.get("reasonForIncompletion"),
-            callback_after_seconds=server_json_dict.get("callbackAfterSeconds"),
-            worker_id=server_json_dict.get("workerId"),
-            status=server_json_dict.get("status"),
-            output_data=server_json_dict.get("outputData"),
-            logs=[TaskExecLog(log.get("log")) for log in server_json_dict.get("logs", [])],
-            external_output_payload_storage_path=server_json_dict.get("externalOutputPayloadStoragePath"),
-            sub_workflow_id=server_json_dict.get("subWorkflowId"),
-            extend_lease=server_json_dict.get("extendLease", False)
+
+def test_task_result_serdeser(server_json_str):
+    # Step 1: Deserialize JSON into TaskResult object
+    server_json_dict = json.loads(server_json_str)
+    task_result = TaskResult(
+        workflow_instance_id=server_json_dict.get("workflowInstanceId"),
+        task_id=server_json_dict.get("taskId"),
+        reason_for_incompletion=server_json_dict.get("reasonForIncompletion"),
+        callback_after_seconds=server_json_dict.get("callbackAfterSeconds"),
+        worker_id=server_json_dict.get("workerId"),
+        status=server_json_dict.get("status"),
+        output_data=server_json_dict.get("outputData"),
+        logs=[TaskExecLog(log.get("log")) for log in server_json_dict.get("logs", [])],
+        external_output_payload_storage_path=server_json_dict.get(
+            "externalOutputPayloadStoragePath"
+        ),
+        sub_workflow_id=server_json_dict.get("subWorkflowId"),
+        extend_lease=server_json_dict.get("extendLease", False),
+    )
+    # Step 2: Verify all fields are properly populated
+    assert (
+        server_json_dict.get("workflowInstanceId") == task_result.workflow_instance_id
+    )
+    assert server_json_dict.get("taskId") == task_result.task_id
+    assert (
+        server_json_dict.get("reasonForIncompletion")
+        == task_result.reason_for_incompletion
+    )
+    assert (
+        server_json_dict.get("callbackAfterSeconds")
+        == task_result.callback_after_seconds
+    )
+    assert server_json_dict.get("workerId") == task_result.worker_id
+    # Verify enum status is correctly converted
+    if server_json_dict.get("status"):
+        assert isinstance(task_result.status, TaskResultStatus)
+        assert server_json_dict.get("status") == task_result.status.name
+    # Verify output_data map
+    assert server_json_dict.get("outputData") == task_result.output_data
+    # Verify logs list
+    if server_json_dict.get("logs"):
+        assert len(server_json_dict.get("logs")) == len(task_result.logs)
+        for i, log in enumerate(server_json_dict.get("logs", [])):
+            assert log.get("log") == task_result.logs[i].log
+    assert (
+        server_json_dict.get("externalOutputPayloadStoragePath")
+        == task_result.external_output_payload_storage_path
+    )
+    assert server_json_dict.get("subWorkflowId") == task_result.sub_workflow_id
+    assert server_json_dict.get("extendLease", False) == task_result.extend_lease
+    # Step 3: Serialize back to JSON
+    serialized_json_dict = task_result.to_dict()
+    # Step 4: Verify the resulting JSON matches the original
+    # Check field by field to ensure no data is lost
+    assert server_json_dict.get("workflowInstanceId") == serialized_json_dict.get(
+        "workflow_instance_id"
+    )
+    assert server_json_dict.get("taskId") == serialized_json_dict.get("task_id")
+    assert server_json_dict.get("reasonForIncompletion") == serialized_json_dict.get(
+        "reason_for_incompletion"
+    )
+    assert server_json_dict.get("callbackAfterSeconds") == serialized_json_dict.get(
+        "callback_after_seconds"
+    )
+    assert server_json_dict.get("workerId") == serialized_json_dict.get("worker_id")
+    # Check status - need to convert enum to string when comparing
+    if server_json_dict.get("status"):
+        assert server_json_dict.get("status") == serialized_json_dict.get("status").name
+    # Check output_data map
+    assert server_json_dict.get("outputData") == serialized_json_dict.get("output_data")
+    # Check logs list - in serialized version, logs are returned as dictionaries
+    if server_json_dict.get("logs"):
+        assert len(server_json_dict.get("logs")) == len(
+            serialized_json_dict.get("logs")
         )
-
-        # Step 2: Verify all fields are properly populated
-        self.assertEqual(server_json_dict.get("workflowInstanceId"), task_result.workflow_instance_id)
-        self.assertEqual(server_json_dict.get("taskId"), task_result.task_id)
-        self.assertEqual(server_json_dict.get("reasonForIncompletion"), task_result.reason_for_incompletion)
-        self.assertEqual(server_json_dict.get("callbackAfterSeconds"), task_result.callback_after_seconds)
-        self.assertEqual(server_json_dict.get("workerId"), task_result.worker_id)
-
-        # Verify enum status is correctly converted
-        if server_json_dict.get("status"):
-            self.assertIsInstance(task_result.status, TaskResultStatus)
-            self.assertEqual(server_json_dict.get("status"), task_result.status.name)
-
-        # Verify output_data map
-        self.assertEqual(server_json_dict.get("outputData"), task_result.output_data)
-
-        # Verify logs list
-        if server_json_dict.get("logs"):
-            self.assertEqual(len(server_json_dict.get("logs")), len(task_result.logs))
-            for i, log in enumerate(server_json_dict.get("logs", [])):
-                self.assertEqual(log.get("log"), task_result.logs[i].log)
-
-        self.assertEqual(server_json_dict.get("externalOutputPayloadStoragePath"),
-                         task_result.external_output_payload_storage_path)
-        self.assertEqual(server_json_dict.get("subWorkflowId"), task_result.sub_workflow_id)
-        self.assertEqual(server_json_dict.get("extendLease", False), task_result.extend_lease)
-
-        # Step 3: Serialize back to JSON
-        serialized_json_dict = task_result.to_dict()
-
-        # Step 4: Verify the resulting JSON matches the original
-        # Check field by field to ensure no data is lost
-        self.assertEqual(server_json_dict.get("workflowInstanceId"),
-                         serialized_json_dict.get("workflow_instance_id"))
-        self.assertEqual(server_json_dict.get("taskId"),
-                         serialized_json_dict.get("task_id"))
-        self.assertEqual(server_json_dict.get("reasonForIncompletion"),
-                         serialized_json_dict.get("reason_for_incompletion"))
-        self.assertEqual(server_json_dict.get("callbackAfterSeconds"),
-                         serialized_json_dict.get("callback_after_seconds"))
-        self.assertEqual(server_json_dict.get("workerId"),
-                         serialized_json_dict.get("worker_id"))
-
-        # Check status - need to convert enum to string when comparing
-        if server_json_dict.get("status"):
-            self.assertEqual(server_json_dict.get("status"),
-                             serialized_json_dict.get("status").name)
-
-        # Check output_data map
-        self.assertEqual(server_json_dict.get("outputData"),
-                         serialized_json_dict.get("output_data"))
-
-        # Check logs list - in serialized version, logs are returned as dictionaries
-        if server_json_dict.get("logs"):
-            self.assertEqual(len(server_json_dict.get("logs")),
-                             len(serialized_json_dict.get("logs")))
-            for i, orig_log in enumerate(server_json_dict.get("logs", [])):
-                serialized_log = serialized_json_dict.get("logs")[i]
-                # Check that the serialized log dictionary has the expected structure
-                self.assertEqual(orig_log.get("log"), serialized_log.get("log"))
-
-        self.assertEqual(server_json_dict.get("externalOutputPayloadStoragePath"),
-                         serialized_json_dict.get("external_output_payload_storage_path"))
-        self.assertEqual(server_json_dict.get("subWorkflowId"),
-                         serialized_json_dict.get("sub_workflow_id"))
-        self.assertEqual(server_json_dict.get("extendLease", False),
-                         serialized_json_dict.get("extend_lease"))
-
-
-if __name__ == "__main__":
-    unittest.main()
+        for i, orig_log in enumerate(server_json_dict.get("logs", [])):
+            serialized_log = serialized_json_dict.get("logs")[i]
+            # Check that the serialized log dictionary has the expected structure
+            assert orig_log.get("log") == serialized_log.get("log")
+    assert server_json_dict.get(
+        "externalOutputPayloadStoragePath"
+    ) == serialized_json_dict.get("external_output_payload_storage_path")
+    assert server_json_dict.get("subWorkflowId") == serialized_json_dict.get(
+        "sub_workflow_id"
+    )
+    assert server_json_dict.get("extendLease", False) == serialized_json_dict.get(
+        "extend_lease"
+    )

--- a/tests/serdesertest/test_serdeser_task_result_status.py
+++ b/tests/serdesertest/test_serdeser_task_result_status.py
@@ -1,127 +1,94 @@
-import unittest
 import json
-from conductor.client.http.models.task_result import TaskResult, TaskResultStatus, TaskExecLog
+
+import pytest
+
+from conductor.client.http.models.task_result import (
+    TaskResult,
+    TaskResultStatus,
+)
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestTaskResultSerde(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("TaskResult")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_task_result_serde(self):
-        # 1. Create TaskResult object using constructor
-        task_result = TaskResult()
-
-        # Populate basic fields
-        task_result.workflow_instance_id = self.server_json.get("workflowInstanceId")
-        task_result.task_id = self.server_json.get("taskId")
-        task_result.reason_for_incompletion = self.server_json.get("reasonForIncompletion")
-        task_result.callback_after_seconds = self.server_json.get("callbackAfterSeconds", 0)
-        task_result.worker_id = self.server_json.get("workerId")
-
-        # Handle enum conversion for status
-        status_str = self.server_json.get("status")
-        if status_str:
-            task_result.status = TaskResultStatus[status_str]
-
-        # Handle output_data dictionary
-        task_result.output_data = self.server_json.get("outputData", {})
-
-        # Handle logs - use the log() method to add logs
-        logs_json = self.server_json.get("logs", [])
-        for log_entry in logs_json:
-            if isinstance(log_entry, dict) and "log" in log_entry:
-                task_result.log(log_entry["log"])
-
-        # Set remaining fields
-        task_result.external_output_payload_storage_path = self.server_json.get("externalOutputPayloadStoragePath")
-        task_result.sub_workflow_id = self.server_json.get("subWorkflowId")
-        task_result.extend_lease = self.server_json.get("extendLease", False)
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(task_result.workflow_instance_id, self.server_json.get("workflowInstanceId"))
-        self.assertEqual(task_result.task_id, self.server_json.get("taskId"))
-        self.assertEqual(task_result.reason_for_incompletion, self.server_json.get("reasonForIncompletion"))
-        self.assertEqual(task_result.callback_after_seconds, self.server_json.get("callbackAfterSeconds", 0))
-        self.assertEqual(task_result.worker_id, self.server_json.get("workerId"))
-
-        # Check enum field (status)
-        if status_str:
-            self.assertEqual(task_result.status.name, status_str)
-
-        # Check dictionary (output_data)
-        self.assertEqual(task_result.output_data, self.server_json.get("outputData", {}))
-
-        # Check list of TaskExecLog objects
-        self.assertEqual(len(task_result.logs), len(logs_json))
-        for i, log_entry in enumerate(logs_json):
-            if isinstance(log_entry, dict) and "log" in log_entry:
-                self.assertEqual(task_result.logs[i].log, log_entry["log"])
-
-        # Check remaining fields
-        self.assertEqual(task_result.external_output_payload_storage_path,
-                         self.server_json.get("externalOutputPayloadStoragePath"))
-        self.assertEqual(task_result.sub_workflow_id, self.server_json.get("subWorkflowId"))
-        self.assertEqual(task_result.extend_lease, self.server_json.get("extendLease", False))
-
-        # 3. Serialize the TaskResult to a dictionary
-        serialized_dict = task_result.to_dict()
+@pytest.fixture
+def server_json():
+    return json.loads(JsonTemplateResolver.get_json_string("TaskResult"))
 
 
-        # 4. Check field by field based on what's actually in the serialized dict
-        # This is a more robust approach that will work even if field names change
-
-        # For basic string/number fields, check equivalence if the field exists
-        fields_to_check = [
-            # (serialized_key, server_json_key)
-            ("workflowInstanceId", "workflowInstanceId"),
-            ("workflow_instance_id", "workflowInstanceId"),
-            ("taskId", "taskId"),
-            ("task_id", "taskId"),
-            ("reasonForIncompletion", "reasonForIncompletion"),
-            ("reason_for_incompletion", "reasonForIncompletion"),
-            ("callbackAfterSeconds", "callbackAfterSeconds"),
-            ("callback_after_seconds", "callbackAfterSeconds"),
-            ("workerId", "workerId"),
-            ("worker_id", "workerId"),
-            ("externalOutputPayloadStoragePath", "externalOutputPayloadStoragePath"),
-            ("external_output_payload_storage_path", "externalOutputPayloadStoragePath"),
-            ("subWorkflowId", "subWorkflowId"),
-            ("sub_workflow_id", "subWorkflowId"),
-            ("extendLease", "extendLease"),
-            ("extend_lease", "extendLease"),
-        ]
-
-        for serialized_key, server_key in fields_to_check:
-            if serialized_key in serialized_dict:
-                self.assertEqual(serialized_dict[serialized_key], self.server_json.get(server_key))
-                print(f"Matched field: {serialized_key} = {server_key}")
-
-        # Check status (handling the enum conversion)
-        status_keys = ["status", "_status"]
-        for key in status_keys:
-            if key in serialized_dict and serialized_dict[key] is not None and status_str:
-                if isinstance(serialized_dict[key], str):
-                    self.assertEqual(serialized_dict[key], status_str)
-                else:
-                    self.assertEqual(serialized_dict[key].name, status_str)
-                print(f"Matched status field: {key}")
-
-        # Check output data
-        output_data_keys = ["outputData", "output_data", "_output_data"]
-        for key in output_data_keys:
-            if key in serialized_dict:
-                self.assertEqual(serialized_dict[key], self.server_json.get("outputData", {}))
-                print(f"Matched output data field: {key}")
-
-        # Check logs (just length check for now)
-        logs_keys = ["logs", "_logs"]
-        for key in logs_keys:
-            if key in serialized_dict:
-                self.assertEqual(len(serialized_dict[key]), len(logs_json))
-                print(f"Matched logs length: {key}")
-
-
-if __name__ == "__main__":
-    unittest.main()
+def test_task_result_serde(server_json):
+    task_result = TaskResult()
+    task_result.workflow_instance_id = server_json.get("workflowInstanceId")
+    task_result.task_id = server_json.get("taskId")
+    task_result.reason_for_incompletion = server_json.get("reasonForIncompletion")
+    task_result.callback_after_seconds = server_json.get("callbackAfterSeconds", 0)
+    task_result.worker_id = server_json.get("workerId")
+    status_str = server_json.get("status")
+    if status_str:
+        task_result.status = TaskResultStatus[status_str]
+    task_result.output_data = server_json.get("outputData", {})
+    logs_json = server_json.get("logs", [])
+    for log_entry in logs_json:
+        if isinstance(log_entry, dict) and "log" in log_entry:
+            task_result.log(log_entry["log"])
+    task_result.external_output_payload_storage_path = server_json.get(
+        "externalOutputPayloadStoragePath"
+    )
+    task_result.sub_workflow_id = server_json.get("subWorkflowId")
+    task_result.extend_lease = server_json.get("extendLease", False)
+    assert task_result.workflow_instance_id == server_json.get("workflowInstanceId")
+    assert task_result.task_id == server_json.get("taskId")
+    assert task_result.reason_for_incompletion == server_json.get(
+        "reasonForIncompletion"
+    )
+    assert task_result.callback_after_seconds == server_json.get(
+        "callbackAfterSeconds", 0
+    )
+    assert task_result.worker_id == server_json.get("workerId")
+    if status_str:
+        assert task_result.status.name == status_str
+    assert task_result.output_data == server_json.get("outputData", {})
+    assert len(task_result.logs) == len(logs_json)
+    for i, log_entry in enumerate(logs_json):
+        if isinstance(log_entry, dict) and "log" in log_entry:
+            assert task_result.logs[i].log == log_entry["log"]
+    assert task_result.external_output_payload_storage_path == server_json.get(
+        "externalOutputPayloadStoragePath"
+    )
+    assert task_result.sub_workflow_id == server_json.get("subWorkflowId")
+    assert task_result.extend_lease == server_json.get("extendLease", False)
+    serialized_dict = task_result.to_dict()
+    fields_to_check = [
+        ("workflowInstanceId", "workflowInstanceId"),
+        ("workflow_instance_id", "workflowInstanceId"),
+        ("taskId", "taskId"),
+        ("task_id", "taskId"),
+        ("reasonForIncompletion", "reasonForIncompletion"),
+        ("reason_for_incompletion", "reasonForIncompletion"),
+        ("callbackAfterSeconds", "callbackAfterSeconds"),
+        ("callback_after_seconds", "callbackAfterSeconds"),
+        ("workerId", "workerId"),
+        ("worker_id", "workerId"),
+        ("externalOutputPayloadStoragePath", "externalOutputPayloadStoragePath"),
+        ("external_output_payload_storage_path", "externalOutputPayloadStoragePath"),
+        ("subWorkflowId", "subWorkflowId"),
+        ("sub_workflow_id", "subWorkflowId"),
+        ("extendLease", "extendLease"),
+        ("extend_lease", "extendLease"),
+    ]
+    for serialized_key, server_key in fields_to_check:
+        if serialized_key in serialized_dict:
+            assert serialized_dict[serialized_key] == server_json.get(server_key)
+    status_keys = ["status", "_status"]
+    for key in status_keys:
+        if key in serialized_dict and serialized_dict[key] is not None and status_str:
+            if isinstance(serialized_dict[key], str):
+                assert serialized_dict[key] == status_str
+            else:
+                assert serialized_dict[key].name == status_str
+    output_data_keys = ["outputData", "output_data", "_output_data"]
+    for key in output_data_keys:
+        if key in serialized_dict:
+            assert serialized_dict[key] == server_json.get("outputData", {})
+    logs_keys = ["logs", "_logs"]
+    for key in logs_keys:
+        if key in serialized_dict:
+            assert len(serialized_dict[key]) == len(logs_json)

--- a/tests/serdesertest/test_serdeser_task_summary.py
+++ b/tests/serdesertest/test_serdeser_task_summary.py
@@ -1,88 +1,90 @@
-import unittest
 import json
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
+
+import pytest
+
 from conductor.client.http.models.task_summary import TaskSummary
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestTaskSummarySerDeser(unittest.TestCase):
-    def setUp(self):
-        # Load JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("TaskSummary")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_task_summary_ser_deser(self):
-        # 1. Deserialize JSON to TaskSummary object
-        task_summary = TaskSummary(
-            workflow_id=self.server_json.get('workflowId'),
-            workflow_type=self.server_json.get('workflowType'),
-            correlation_id=self.server_json.get('correlationId'),
-            scheduled_time=self.server_json.get('scheduledTime'),
-            start_time=self.server_json.get('startTime'),
-            update_time=self.server_json.get('updateTime'),
-            end_time=self.server_json.get('endTime'),
-            status=self.server_json.get('status'),
-            reason_for_incompletion=self.server_json.get('reasonForIncompletion'),
-            execution_time=self.server_json.get('executionTime'),
-            queue_wait_time=self.server_json.get('queueWaitTime'),
-            task_def_name=self.server_json.get('taskDefName'),
-            task_type=self.server_json.get('taskType'),
-            input=self.server_json.get('input'),
-            output=self.server_json.get('output'),
-            task_id=self.server_json.get('taskId'),
-            external_input_payload_storage_path=self.server_json.get('externalInputPayloadStoragePath'),
-            external_output_payload_storage_path=self.server_json.get('externalOutputPayloadStoragePath'),
-            workflow_priority=self.server_json.get('workflowPriority'),
-            domain=self.server_json.get('domain')
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get('workflowId'), task_summary.workflow_id)
-        self.assertEqual(self.server_json.get('workflowType'), task_summary.workflow_type)
-        self.assertEqual(self.server_json.get('correlationId'), task_summary.correlation_id)
-        self.assertEqual(self.server_json.get('scheduledTime'), task_summary.scheduled_time)
-        self.assertEqual(self.server_json.get('startTime'), task_summary.start_time)
-        self.assertEqual(self.server_json.get('updateTime'), task_summary.update_time)
-        self.assertEqual(self.server_json.get('endTime'), task_summary.end_time)
-        self.assertEqual(self.server_json.get('status'), task_summary.status)
-        self.assertEqual(self.server_json.get('reasonForIncompletion'), task_summary.reason_for_incompletion)
-        self.assertEqual(self.server_json.get('executionTime'), task_summary.execution_time)
-        self.assertEqual(self.server_json.get('queueWaitTime'), task_summary.queue_wait_time)
-        self.assertEqual(self.server_json.get('taskDefName'), task_summary.task_def_name)
-        self.assertEqual(self.server_json.get('taskType'), task_summary.task_type)
-        self.assertEqual(self.server_json.get('input'), task_summary.input)
-        self.assertEqual(self.server_json.get('output'), task_summary.output)
-        self.assertEqual(self.server_json.get('taskId'), task_summary.task_id)
-        self.assertEqual(self.server_json.get('externalInputPayloadStoragePath'),
-                         task_summary.external_input_payload_storage_path)
-        self.assertEqual(self.server_json.get('externalOutputPayloadStoragePath'),
-                         task_summary.external_output_payload_storage_path)
-        self.assertEqual(self.server_json.get('workflowPriority'), task_summary.workflow_priority)
-        self.assertEqual(self.server_json.get('domain'), task_summary.domain)
-
-        # 3. Serialize TaskSummary back to JSON
-        serialized_json = task_summary.to_dict()
-
-        # 4. Verify serialized JSON matches original
-        # Check that all fields from original JSON are present in serialized JSON
-        for json_key, json_value in self.server_json.items():
-            # Convert camelCase to snake_case for comparison
-            python_key = ''.join(['_' + c.lower() if c.isupper() else c for c in json_key])
-            python_key = python_key.lstrip('_')
-
-            # Get the corresponding value from serialized JSON
-            self.assertIn(python_key, serialized_json)
-            self.assertEqual(json_value, serialized_json[python_key])
-
-        # Check that all fields from serialized JSON are present in original JSON
-        for python_key, python_value in serialized_json.items():
-            # Convert snake_case to camelCase for comparison
-            parts = python_key.split('_')
-            json_key = parts[0] + ''.join(x.title() for x in parts[1:])
-
-            # Get the corresponding value from original JSON
-            self.assertIn(json_key, self.server_json)
-            self.assertEqual(python_value, self.server_json[json_key])
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("TaskSummary")
+    return json.loads(server_json_str)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_task_summary_ser_deser(server_json):
+    # 1. Deserialize JSON to TaskSummary object
+    task_summary = TaskSummary(
+        workflow_id=server_json.get("workflowId"),
+        workflow_type=server_json.get("workflowType"),
+        correlation_id=server_json.get("correlationId"),
+        scheduled_time=server_json.get("scheduledTime"),
+        start_time=server_json.get("startTime"),
+        update_time=server_json.get("updateTime"),
+        end_time=server_json.get("endTime"),
+        status=server_json.get("status"),
+        reason_for_incompletion=server_json.get("reasonForIncompletion"),
+        execution_time=server_json.get("executionTime"),
+        queue_wait_time=server_json.get("queueWaitTime"),
+        task_def_name=server_json.get("taskDefName"),
+        task_type=server_json.get("taskType"),
+        input=server_json.get("input"),
+        output=server_json.get("output"),
+        task_id=server_json.get("taskId"),
+        external_input_payload_storage_path=server_json.get(
+            "externalInputPayloadStoragePath"
+        ),
+        external_output_payload_storage_path=server_json.get(
+            "externalOutputPayloadStoragePath"
+        ),
+        workflow_priority=server_json.get("workflowPriority"),
+        domain=server_json.get("domain"),
+    )
+    # 2. Verify all fields are properly populated
+    assert server_json.get("workflowId") == task_summary.workflow_id
+    assert server_json.get("workflowType") == task_summary.workflow_type
+    assert server_json.get("correlationId") == task_summary.correlation_id
+    assert server_json.get("scheduledTime") == task_summary.scheduled_time
+    assert server_json.get("startTime") == task_summary.start_time
+    assert server_json.get("updateTime") == task_summary.update_time
+    assert server_json.get("endTime") == task_summary.end_time
+    assert server_json.get("status") == task_summary.status
+    assert (
+        server_json.get("reasonForIncompletion") == task_summary.reason_for_incompletion
+    )
+    assert server_json.get("executionTime") == task_summary.execution_time
+    assert server_json.get("queueWaitTime") == task_summary.queue_wait_time
+    assert server_json.get("taskDefName") == task_summary.task_def_name
+    assert server_json.get("taskType") == task_summary.task_type
+    assert server_json.get("input") == task_summary.input
+    assert server_json.get("output") == task_summary.output
+    assert server_json.get("taskId") == task_summary.task_id
+    assert (
+        server_json.get("externalInputPayloadStoragePath")
+        == task_summary.external_input_payload_storage_path
+    )
+    assert (
+        server_json.get("externalOutputPayloadStoragePath")
+        == task_summary.external_output_payload_storage_path
+    )
+    assert server_json.get("workflowPriority") == task_summary.workflow_priority
+    assert server_json.get("domain") == task_summary.domain
+    # 3. Serialize TaskSummary back to JSON
+    serialized_json = task_summary.to_dict()
+    # 4. Verify serialized JSON matches original
+    # Check that all fields from original JSON are present in serialized JSON
+    for json_key, json_value in server_json.items():
+        # Convert camelCase to snake_case for comparison
+        python_key = "".join(["_" + c.lower() if c.isupper() else c for c in json_key])
+        python_key = python_key.lstrip("_")
+        # Get the corresponding value from serialized JSON
+        assert python_key in serialized_json
+        assert json_value == serialized_json[python_key]
+    # Check that all fields from serialized JSON are present in original JSON
+    for python_key, python_value in serialized_json.items():
+        # Convert snake_case to camelCase for comparison
+        parts = python_key.split("_")
+        json_key = parts[0] + "".join(x.title() for x in parts[1:])
+        # Get the corresponding value from original JSON
+        assert json_key in server_json
+        assert python_value == server_json[json_key]

--- a/tests/serdesertest/test_serdeser_terminate_workflow.py
+++ b/tests/serdesertest/test_serdeser_terminate_workflow.py
@@ -1,47 +1,39 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.terminate_workflow import TerminateWorkflow
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestTerminateWorkflowSerDes(unittest.TestCase):
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string(
+        "EventHandler.TerminateWorkflow"
+    )
+    return json.loads(server_json_str)
+
+
+def test_terminate_workflow_ser_des(server_json):
     """Test serialization and deserialization of TerminateWorkflow model."""
-
-    def setUp(self):
-        """Set up test environment."""
-        self.server_json_str = JsonTemplateResolver.get_json_string("EventHandler.TerminateWorkflow")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_terminate_workflow_ser_des(self):
-        """Test serialization and deserialization of TerminateWorkflow model."""
-        # 1. Verify server JSON can be correctly deserialized
-        model_obj = TerminateWorkflow(
-            workflow_id=self.server_json["workflowId"],
-            termination_reason=self.server_json["terminationReason"]
-        )
-
-        # 2. Verify all fields are properly populated during deserialization
-        self.assertEqual(self.server_json["workflowId"], model_obj.workflow_id)
-        self.assertEqual(self.server_json["terminationReason"], model_obj.termination_reason)
-
-        # 3. Verify SDK model can be serialized back to JSON
-        result_json = model_obj.to_dict()
-
-        # 4. Verify resulting JSON matches original
-        self.assertEqual(self.server_json["workflowId"], result_json["workflowId"])
-        self.assertEqual(self.server_json["terminationReason"], result_json["terminationReason"])
-
-        # Verify no data loss by checking all keys exist
-        for key in self.server_json:
-            self.assertIn(key, result_json)
-
-        # Verify no extra keys were added
-        self.assertEqual(len(self.server_json), len(result_json))
-
-        # Check string representation
-        self.assertIn(model_obj.workflow_id, repr(model_obj))
-        self.assertIn(model_obj.termination_reason, repr(model_obj))
-
-
-if __name__ == "__main__":
-    unittest.main()
+    # 1. Verify server JSON can be correctly deserialized
+    model_obj = TerminateWorkflow(
+        workflow_id=server_json["workflowId"],
+        termination_reason=server_json["terminationReason"],
+    )
+    # 2. Verify all fields are properly populated during deserialization
+    assert server_json["workflowId"] == model_obj.workflow_id
+    assert server_json["terminationReason"] == model_obj.termination_reason
+    # 3. Verify SDK model can be serialized back to JSON
+    result_json = model_obj.to_dict()
+    # 4. Verify resulting JSON matches original
+    assert server_json["workflowId"] == result_json["workflowId"]
+    assert server_json["terminationReason"] == result_json["terminationReason"]
+    # Verify no data loss by checking all keys exist
+    for key in server_json:
+        assert key in result_json
+    # Verify no extra keys were added
+    assert len(server_json) == len(result_json)
+    # Check string representation
+    assert model_obj.workflow_id in repr(model_obj)
+    assert model_obj.termination_reason in repr(model_obj)

--- a/tests/serdesertest/test_serdeser_update_workflow_variables.py
+++ b/tests/serdesertest/test_serdeser_update_workflow_variables.py
@@ -1,52 +1,46 @@
 import json
-import unittest
-from dataclasses import asdict
-from conductor.client.http.models.update_workflow_variables import UpdateWorkflowVariables
+
+import pytest
+
+from conductor.client.http.models.update_workflow_variables import (
+    UpdateWorkflowVariables,
+)
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestUpdateWorkflowVariables(unittest.TestCase):
-    """Test serialization and deserialization of UpdateWorkflowVariables model."""
-
-    def setUp(self):
-        """Set up test fixtures."""
-        self.server_json_str = JsonTemplateResolver.get_json_string("EventHandler.UpdateWorkflowVariables")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_update_workflow_variables_serde(self):
-        """Test serialization and deserialization of UpdateWorkflowVariables.
-
-        Verifies:
-        1. Server JSON can be correctly deserialized into SDK model object
-        2. All fields are properly populated during deserialization
-        3. The SDK model can be serialized back to JSON
-        4. The resulting JSON matches the original
-        """
-        # 1. Deserialize JSON into model object
-        model = UpdateWorkflowVariables(
-            workflow_id=self.server_json.get("workflowId"),
-            variables=self.server_json.get("variables"),
-            append_array=self.server_json.get("appendArray")
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(model.workflow_id, self.server_json.get("workflowId"))
-        self.assertEqual(model.variables, self.server_json.get("variables"))
-        self.assertEqual(model.append_array, self.server_json.get("appendArray"))
-
-        # Verify complex data structures (if present)
-        if model.variables:
-            self.assertIsInstance(model.variables, dict)
-            # Additional verification for specific variable types could be added here
-
-        # 3. Serialize model back to JSON
-        model_json = model.to_dict()
-
-        # 4. Verify the resulting JSON matches the original
-        self.assertEqual(model_json.get("workflowId"), self.server_json.get("workflowId"))
-        self.assertEqual(model_json.get("variables"), self.server_json.get("variables"))
-        self.assertEqual(model_json.get("appendArray"), self.server_json.get("appendArray"))
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string(
+        "EventHandler.UpdateWorkflowVariables"
+    )
+    return json.loads(server_json_str)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_update_workflow_variables_serde(server_json):
+    """Test serialization and deserialization of UpdateWorkflowVariables.
+    Verifies:
+    1. Server JSON can be correctly deserialized into SDK model object
+    2. All fields are properly populated during deserialization
+    3. The SDK model can be serialized back to JSON
+    4. The resulting JSON matches the original
+    """
+    # 1. Deserialize JSON into model object
+    model = UpdateWorkflowVariables(
+        workflow_id=server_json.get("workflowId"),
+        variables=server_json.get("variables"),
+        append_array=server_json.get("appendArray"),
+    )
+    # 2. Verify all fields are properly populated
+    assert model.workflow_id == server_json.get("workflowId")
+    assert model.variables == server_json.get("variables")
+    assert model.append_array == server_json.get("appendArray")
+    # Verify complex data structures (if present)
+    if model.variables:
+        assert isinstance(model.variables, dict)
+        # Additional verification for specific variable types could be added here
+    # 3. Serialize model back to JSON
+    model_json = model.to_dict()
+    # 4. Verify the resulting JSON matches the original
+    assert model_json.get("workflowId") == server_json.get("workflowId")
+    assert model_json.get("variables") == server_json.get("variables")
+    assert model_json.get("appendArray") == server_json.get("appendArray")

--- a/tests/serdesertest/test_serdeser_upsert_group_request.py
+++ b/tests/serdesertest/test_serdeser_upsert_group_request.py
@@ -1,55 +1,52 @@
-import unittest
 import json
+
+import pytest
+
 from conductor.client.http.models.upsert_group_request import UpsertGroupRequest
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestUpsertGroupRequest(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template using JsonTemplateResolver
-        self.server_json_str = JsonTemplateResolver.get_json_string("UpsertGroupRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_serde_upsert_group_request(self):
-        # 1. Deserialize JSON into model object
-        model_obj = UpsertGroupRequest(
-            description=self.server_json.get("description"),
-            roles=self.server_json.get("roles"),
-            default_access=self.server_json.get("defaultAccess")
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(model_obj.description, self.server_json.get("description"))
-
-        # Check roles list is populated correctly
-        self.assertIsNotNone(model_obj.roles)
-        self.assertEqual(len(model_obj.roles), len(self.server_json.get("roles", [])))
-        for role in model_obj.roles:
-            self.assertIn(role, ["ADMIN", "USER", "WORKER", "METADATA_MANAGER", "WORKFLOW_MANAGER"])
-
-        # Check default_access map is populated correctly
-        self.assertIsNotNone(model_obj.default_access)
-        self.assertEqual(len(model_obj.default_access), len(self.server_json.get("defaultAccess", {})))
-
-        # Verify all keys in default_access are valid
-        for key in model_obj.default_access:
-            self.assertIn(key, ["WORKFLOW_DEF", "TASK_DEF"])
-
-        # 3. Serialize the model back to dict/JSON
-        model_dict = model_obj.to_dict()
-
-        # 4. Verify the serialized JSON matches the original
-        # Check that snake_case in Python is properly converted to camelCase in JSON
-        self.assertEqual(model_dict["default_access"], self.server_json.get("defaultAccess"))
-        self.assertEqual(model_dict["description"], self.server_json.get("description"))
-        self.assertEqual(model_dict["roles"], self.server_json.get("roles"))
-
-        # Additional validation for complex nested structures
-        if "defaultAccess" in self.server_json:
-            for target_type, access_list in self.server_json["defaultAccess"].items():
-                self.assertIn(target_type, model_dict["default_access"])
-                self.assertEqual(access_list, model_dict["default_access"][target_type])
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("UpsertGroupRequest")
+    return json.loads(server_json_str)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_serde_upsert_group_request(server_json):
+    # 1. Deserialize JSON into model object
+    model_obj = UpsertGroupRequest(
+        description=server_json.get("description"),
+        roles=server_json.get("roles"),
+        default_access=server_json.get("defaultAccess"),
+    )
+    # 2. Verify all fields are properly populated
+    assert model_obj.description == server_json.get("description")
+    # Check roles list is populated correctly
+    assert model_obj.roles is not None
+    assert len(model_obj.roles) == len(server_json.get("roles", []))
+    for role in model_obj.roles:
+        assert role in [
+            "ADMIN",
+            "USER",
+            "WORKER",
+            "METADATA_MANAGER",
+            "WORKFLOW_MANAGER",
+        ]
+    # Check default_access map is populated correctly
+    assert model_obj.default_access is not None
+    assert len(model_obj.default_access) == len(server_json.get("defaultAccess", {}))
+    # Verify all keys in default_access are valid
+    for key in model_obj.default_access:
+        assert key in ["WORKFLOW_DEF", "TASK_DEF"]
+    # 3. Serialize the model back to dict/JSON
+    model_dict = model_obj.to_dict()
+    # 4. Verify the serialized JSON matches the original
+    # Check that snake_case in Python is properly converted to camelCase in JSON
+    assert model_dict["default_access"] == server_json.get("defaultAccess")
+    assert model_dict["description"] == server_json.get("description")
+    assert model_dict["roles"] == server_json.get("roles")
+    # Additional validation for complex nested structures
+    if "defaultAccess" in server_json:
+        for target_type, access_list in server_json["defaultAccess"].items():
+            assert target_type in model_dict["default_access"]
+            assert access_list == model_dict["default_access"][target_type]

--- a/tests/serdesertest/test_serdeser_upsert_user_request.py
+++ b/tests/serdesertest/test_serdeser_upsert_user_request.py
@@ -1,60 +1,55 @@
-import unittest
-from conductor.client.http.models.upsert_user_request import UpsertUserRequest, RolesEnum
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 import json
 
+import pytest
 
-class TestUpsertUserRequestSerdeSer(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("UpsertUserRequest")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_upsert_user_request_serdeser(self):
-        # 1. Deserialize JSON into model object
-        model_obj = UpsertUserRequest(
-            name=self.server_json.get('name'),
-            roles=self.server_json.get('roles'),
-            groups=self.server_json.get('groups')
-        )
-
-        # 2. Verify all fields are properly populated
-        # Verify name field
-        self.assertEqual(self.server_json.get('name'), model_obj.name)
-
-        # Verify roles list and enum values
-        roles = self.server_json.get('roles')
-        if roles:
-            self.assertEqual(len(roles), len(model_obj.roles))
-            for role in model_obj.roles:
-                self.assertIn(role, [e.value for e in RolesEnum])
-                self.assertIn(role, roles)
-
-        # Verify groups list
-        groups = self.server_json.get('groups')
-        if groups:
-            self.assertEqual(len(groups), len(model_obj.groups))
-            for i, group in enumerate(groups):
-                self.assertEqual(group, model_obj.groups[i])
-
-        # 3. Serialize model back to JSON
-        model_dict = model_obj.to_dict()
-        model_json = json.dumps(model_dict)
-
-        # 4. Verify the resulting JSON matches the original
-        # Convert both JSONs to dictionaries for comparison
-        deserialized_json = json.loads(model_json)
-
-        # Compare key by key to handle any field name transformations
-        for key in self.server_json:
-            self.assertIn(key, deserialized_json)
-            if isinstance(self.server_json[key], list):
-                self.assertEqual(len(self.server_json[key]), len(deserialized_json[key]))
-                for i, item in enumerate(self.server_json[key]):
-                    self.assertEqual(item, deserialized_json[key][i])
-            else:
-                self.assertEqual(self.server_json[key], deserialized_json[key])
+from conductor.client.http.models.upsert_user_request import (
+    RolesEnum,
+    UpsertUserRequest,
+)
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("UpsertUserRequest")
+    return json.loads(server_json_str)
+
+
+def test_upsert_user_request_serdeser(server_json):
+    # 1. Deserialize JSON into model object
+    model_obj = UpsertUserRequest(
+        name=server_json.get("name"),
+        roles=server_json.get("roles"),
+        groups=server_json.get("groups"),
+    )
+    # 2. Verify all fields are properly populated
+    # Verify name field
+    assert server_json.get("name") == model_obj.name
+    # Verify roles list and enum values
+    roles = server_json.get("roles")
+    if roles:
+        assert len(roles) == len(model_obj.roles)
+        for role in model_obj.roles:
+            assert role in [e.value for e in RolesEnum]
+            assert role in roles
+    # Verify groups list
+    groups = server_json.get("groups")
+    if groups:
+        assert len(groups) == len(model_obj.groups)
+        for i, group in enumerate(groups):
+            assert group == model_obj.groups[i]
+    # 3. Serialize model back to JSON
+    model_dict = model_obj.to_dict()
+    model_json = json.dumps(model_dict)
+    # 4. Verify the resulting JSON matches the original
+    # Convert both JSONs to dictionaries for comparison
+    deserialized_json = json.loads(model_json)
+    # Compare key by key to handle any field name transformations
+    for key in server_json:
+        assert key in deserialized_json
+        if isinstance(server_json[key], list):
+            assert len(server_json[key]) == len(deserialized_json[key])
+            for i, item in enumerate(server_json[key]):
+                assert item == deserialized_json[key][i]
+        else:
+            assert server_json[key] == deserialized_json[key]

--- a/tests/serdesertest/test_serdeser_workflow.py
+++ b/tests/serdesertest/test_serdeser_workflow.py
@@ -1,198 +1,221 @@
-import unittest
 import json
-from conductor.client.http.models import Workflow, Task, WorkflowDef
+import re
+
+import pytest
+
+from conductor.client.http.models import Task, Workflow, WorkflowDef
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class WorkflowSerDeserTest(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("Workflow")
-        self.server_json = json.loads(self.server_json_str)
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("Workflow")
+    return json.loads(server_json_str)
 
-    def test_workflow_serde(self):
-        # 1. Create a complete workflow object from JSON
-        workflow = self._create_workflow_from_json(self.server_json)
 
-        # 2. Verify all fields are properly populated
-        self._verify_workflow_fields(workflow, self.server_json)
+def test_workflow_serde(server_json):
+    # 1. Create a complete workflow object from JSON
+    workflow = create_workflow_from_json(server_json)
+    # 2. Verify all fields are properly populated
+    verify_workflow_fields(workflow, server_json)
+    # 3. Serialize back to JSON
+    result_json = workflow.to_dict()
+    # 4. Compare original and resulting JSON
+    compare_json_objects(server_json, result_json)
 
-        # 3. Serialize back to JSON
-        result_json = workflow.to_dict()
 
-        # 4. Compare original and resulting JSON
-        self._compare_json_objects(self.server_json, result_json)
-
-    def _create_workflow_from_json(self, json_data):
-        """Create a Workflow object with all fields from JSON"""
-        # Handle tasks if present
-        tasks = None
-        if json_data.get("tasks"):
-            tasks = [self._create_task_from_json(task_json) for task_json in json_data.get("tasks")]
-
-        # Handle workflow definition if present
-        workflow_def = None
-        if json_data.get("workflowDefinition"):
-            workflow_def = self._create_workflow_def_from_json(json_data.get("workflowDefinition"))
-
-        # Handle sets
-        failed_ref_tasks = set(json_data.get("failedReferenceTaskNames", []))
-        failed_tasks = set(json_data.get("failedTaskNames", []))
-
-        # Handle history if present
-        history = None
-        if json_data.get("history"):
-            history = [self._create_workflow_from_json(wf_json) for wf_json in json_data.get("history")]
-
-        # Create the workflow with all fields
-        return Workflow(
-            owner_app=json_data.get("ownerApp"),
-            create_time=json_data.get("createTime"),
-            update_time=json_data.get("updateTime"),
-            created_by=json_data.get("createdBy"),
-            updated_by=json_data.get("updatedBy"),
-            status=json_data.get("status"),
-            end_time=json_data.get("endTime"),
-            workflow_id=json_data.get("workflowId"),
-            parent_workflow_id=json_data.get("parentWorkflowId"),
-            parent_workflow_task_id=json_data.get("parentWorkflowTaskId"),
-            tasks=tasks,
-            input=json_data.get("input"),
-            output=json_data.get("output"),
-            correlation_id=json_data.get("correlationId"),
-            re_run_from_workflow_id=json_data.get("reRunFromWorkflowId"),
-            reason_for_incompletion=json_data.get("reasonForIncompletion"),
-            event=json_data.get("event"),
-            task_to_domain=json_data.get("taskToDomain"),
-            failed_reference_task_names=failed_ref_tasks,
-            workflow_definition=workflow_def,
-            external_input_payload_storage_path=json_data.get("externalInputPayloadStoragePath"),
-            external_output_payload_storage_path=json_data.get("externalOutputPayloadStoragePath"),
-            priority=json_data.get("priority"),
-            variables=json_data.get("variables"),
-            last_retried_time=json_data.get("lastRetriedTime"),
-            failed_task_names=failed_tasks,
-            history=history,
-            idempotency_key=json_data.get("idempotencyKey"),
-            rate_limit_key=json_data.get("rateLimitKey"),
-            rate_limited=json_data.get("rateLimited"),
-            start_time=json_data.get("startTime"),
-            workflow_name=json_data.get("workflowName"),
-            workflow_version=json_data.get("workflowVersion")
+def create_workflow_from_json(json_data):
+    """Create a Workflow object with all fields from JSON"""
+    # Handle tasks if present
+    tasks = None
+    if json_data.get("tasks"):
+        tasks = [
+            create_task_from_json(task_json) for task_json in json_data.get("tasks")
+        ]
+    # Handle workflow definition if present
+    workflow_def = None
+    if json_data.get("workflowDefinition"):
+        workflow_def = create_workflow_def_from_json(
+            json_data.get("workflowDefinition")
         )
+    # Handle sets
+    failed_ref_tasks = set(json_data.get("failedReferenceTaskNames", []))
+    failed_tasks = set(json_data.get("failedTaskNames", []))
+    # Handle history if present
+    history = None
+    if json_data.get("history"):
+        history = [
+            create_workflow_from_json(wf_json) for wf_json in json_data.get("history")
+        ]
+    # Create the workflow with all fields
+    return Workflow(
+        owner_app=json_data.get("ownerApp"),
+        create_time=json_data.get("createTime"),
+        update_time=json_data.get("updateTime"),
+        created_by=json_data.get("createdBy"),
+        updated_by=json_data.get("updatedBy"),
+        status=json_data.get("status"),
+        end_time=json_data.get("endTime"),
+        workflow_id=json_data.get("workflowId"),
+        parent_workflow_id=json_data.get("parentWorkflowId"),
+        parent_workflow_task_id=json_data.get("parentWorkflowTaskId"),
+        tasks=tasks,
+        input=json_data.get("input"),
+        output=json_data.get("output"),
+        correlation_id=json_data.get("correlationId"),
+        re_run_from_workflow_id=json_data.get("reRunFromWorkflowId"),
+        reason_for_incompletion=json_data.get("reasonForIncompletion"),
+        event=json_data.get("event"),
+        task_to_domain=json_data.get("taskToDomain"),
+        failed_reference_task_names=failed_ref_tasks,
+        workflow_definition=workflow_def,
+        external_input_payload_storage_path=json_data.get(
+            "externalInputPayloadStoragePath"
+        ),
+        external_output_payload_storage_path=json_data.get(
+            "externalOutputPayloadStoragePath"
+        ),
+        priority=json_data.get("priority"),
+        variables=json_data.get("variables"),
+        last_retried_time=json_data.get("lastRetriedTime"),
+        failed_task_names=failed_tasks,
+        history=history,
+        idempotency_key=json_data.get("idempotencyKey"),
+        rate_limit_key=json_data.get("rateLimitKey"),
+        rate_limited=json_data.get("rateLimited"),
+        start_time=json_data.get("startTime"),
+        workflow_name=json_data.get("workflowName"),
+        workflow_version=json_data.get("workflowVersion"),
+    )
 
-    def _create_task_from_json(self, task_json):
-        """Create a Task object from JSON"""
-        # Create a Task object with fields from task_json
-        task = Task()
 
-        # Access all possible fields from task_json and set them on the task object
-        for py_field, json_field in Task.attribute_map.items():
-            if json_field in task_json:
-                setattr(task, py_field, task_json.get(json_field))
+def create_task_from_json(task_json):
+    """Create a Task object from JSON"""
+    # Create a Task object with fields from task_json
+    task = Task()
+    # Access all possible fields from task_json and set them on the task object
+    for py_field, json_field in Task.attribute_map.items():
+        if json_field in task_json:
+            setattr(task, py_field, task_json.get(json_field))
+    return task
 
-        return task
 
-    def _create_workflow_def_from_json(self, workflow_def_json):
-        """Create a WorkflowDef object from JSON"""
-        # Create a WorkflowDef object with fields from workflow_def_json
-        workflow_def = WorkflowDef()
+def create_workflow_def_from_json(workflow_def_json):
+    """Create a WorkflowDef object from JSON"""
+    # Create a WorkflowDef object with fields from workflow_def_json
+    workflow_def = WorkflowDef()
+    # Access all possible fields from workflow_def_json and set them on the workflow_def object
+    for py_field, json_field in WorkflowDef.attribute_map.items():
+        if json_field in workflow_def_json:
+            # Special handling for nested objects or complex types could be added here
+            setattr(workflow_def, py_field, workflow_def_json.get(json_field))
+    return workflow_def
 
-        # Access all possible fields from workflow_def_json and set them on the workflow_def object
-        for py_field, json_field in WorkflowDef.attribute_map.items():
-            if json_field in workflow_def_json:
-                # Special handling for nested objects or complex types could be added here
-                setattr(workflow_def, py_field, workflow_def_json.get(json_field))
 
-        return workflow_def
+def verify_workflow_fields(workflow, json_data):
+    """Verify that all fields in the Workflow object match the JSON data"""
+    # Check all fields defined in the model
+    for py_field, json_field in Workflow.attribute_map.items():
+        if json_field in json_data:
+            python_value = getattr(workflow, py_field)
+            json_value = json_data.get(json_field)
+            # Skip complex objects that need special handling
+            if py_field in ["tasks", "workflow_definition", "history"]:
+                continue
+            # Handle sets which need conversion
+            if (
+                py_field in ["failed_reference_task_names", "failed_task_names"]
+                and json_value
+            ):
+                assert set(python_value) == set(json_value)
+                continue
+            # Handle dictionaries and other simple types
+            assert python_value == json_value, f"Field {py_field} doesn't match"
 
-    def _verify_workflow_fields(self, workflow, json_data):
-        """Verify that all fields in the Workflow object match the JSON data"""
-        # Check all fields defined in the model
-        for py_field, json_field in Workflow.attribute_map.items():
-            if json_field in json_data:
-                python_value = getattr(workflow, py_field)
-                json_value = json_data.get(json_field)
 
-                # Skip complex objects that need special handling
-                if py_field in ['tasks', 'workflow_definition', 'history']:
-                    continue
-
-                # Handle sets which need conversion
-                if py_field in ['failed_reference_task_names', 'failed_task_names'] and json_value:
-                    self.assertEqual(set(python_value), set(json_value))
-                    continue
-
-                # Handle dictionaries and other simple types
-                self.assertEqual(python_value, json_value, f"Field {py_field} doesn't match")
-
-    def _compare_json_objects(self, original, result):
-        """Compare original and resulting JSON objects"""
-        # For each field in the original JSON
-        for key in original:
-            if key in result:
-                # Handle sets vs lists conversion for known set fields
-                if key in ["failedReferenceTaskNames", "failedTaskNames"]:
-                    if isinstance(original[key], list) and isinstance(result[key], (list, set)):
-                        self.assertEqual(set(original[key]), set(result[key]),
-                                         f"Field {key} doesn't match after set conversion")
-                    continue
-
-                # If it's a nested object
-                if isinstance(original[key], dict) and isinstance(result[key], dict):
-                    self._compare_json_objects(original[key], result[key])
-                # If it's a list
-                elif isinstance(original[key], list) and isinstance(result[key], list):
-                    self.assertEqual(len(original[key]), len(result[key]))
-                    # For complex objects in lists, we could add recursive comparison
-                # Simple value
-                else:
-                    self.assertEqual(original[key], result[key], f"Field {key} doesn't match")
+def compare_json_objects(original, result):
+    """Compare original and resulting JSON objects"""
+    # For each field in the original JSON
+    for key in original:
+        if key in result:
+            # Handle sets vs lists conversion for known set fields
+            if key in ["failedReferenceTaskNames", "failedTaskNames"]:
+                if isinstance(original[key], list) and isinstance(
+                    result[key], (list, set)
+                ):
+                    assert set(original[key]) == set(
+                        result[key]
+                    ), f"Field {key} doesn't match after set conversion"
+                continue
+            # If it's a nested object
+            if isinstance(original[key], dict) and isinstance(result[key], dict):
+                compare_json_objects(original[key], result[key])
+            # If it's a list
+            elif isinstance(original[key], list) and isinstance(result[key], list):
+                assert len(original[key]) == len(result[key])
+                # For complex objects in lists, we could add recursive comparison
+            # Simple value
             else:
-                # Check if there's a field mapping issue
-                snake_key = self._camel_to_snake(key)
-                if snake_key in result:
-                    # Handle sets vs lists for known set fields
-                    if key in ["failedReferenceTaskNames", "failedTaskNames"]:
-                        if isinstance(original[key], list) and isinstance(result[snake_key], (list, set)):
-                            self.assertEqual(set(original[key]), set(result[snake_key]),
-                                             f"Field {key} doesn't match after set conversion")
-                        continue
-
-                    # Compare with the snake_case key
-                    if isinstance(original[key], dict) and isinstance(result[snake_key], dict):
-                        self._compare_json_objects(original[key], result[snake_key])
-                    elif isinstance(original[key], list) and isinstance(result[snake_key], list):
-                        self.assertEqual(len(original[key]), len(result[snake_key]))
-                    else:
-                        self.assertEqual(original[key], result[snake_key], f"Field {key} doesn't match")
+                assert original[key] == result[key], f"Field {key} doesn't match"
+        else:
+            # Check if there's a field mapping issue
+            snake_key = camel_to_snake(key)
+            if snake_key in result:
+                # Handle sets vs lists for known set fields
+                if key in ["failedReferenceTaskNames", "failedTaskNames"]:
+                    if isinstance(original[key], list) and isinstance(
+                        result[snake_key], (list, set)
+                    ):
+                        assert set(original[key]) == set(
+                            result[snake_key]
+                        ), f"Field {key} doesn't match after set conversion"
+                    continue
+                # Compare with the snake_case key
+                if isinstance(original[key], dict) and isinstance(
+                    result[snake_key], dict
+                ):
+                    compare_json_objects(original[key], result[snake_key])
+                elif isinstance(original[key], list) and isinstance(
+                    result[snake_key], list
+                ):
+                    assert len(original[key]) == len(result[snake_key])
                 else:
-                    # Check if the attribute is defined in swagger_types but has a different JSON name
-                    for py_field, json_field in Workflow.attribute_map.items():
-                        if json_field == key and py_field in result:
-                            if key in ["failedReferenceTaskNames", "failedTaskNames"]:
-                                if isinstance(original[key], list) and isinstance(result[py_field], (list, set)):
-                                    self.assertEqual(set(original[key]), set(result[py_field]),
-                                                     f"Field {key} doesn't match after set conversion")
-                                break
-
-                            if isinstance(original[key], dict) and isinstance(result[py_field], dict):
-                                self._compare_json_objects(original[key], result[py_field])
-                            elif isinstance(original[key], list) and isinstance(result[py_field], list):
-                                self.assertEqual(len(original[key]), len(result[py_field]))
-                            else:
-                                self.assertEqual(original[key], result[py_field], f"Field {key} doesn't match")
+                    assert (
+                        original[key] == result[snake_key]
+                    ), f"Field {key} doesn't match"
+            else:
+                # Check if the attribute is defined in swagger_types but has a different JSON name
+                for py_field, json_field in Workflow.attribute_map.items():
+                    if json_field == key and py_field in result:
+                        if key in ["failedReferenceTaskNames", "failedTaskNames"]:
+                            if isinstance(original[key], list) and isinstance(
+                                result[py_field], (list, set)
+                            ):
+                                assert set(original[key]) == set(
+                                    result[py_field]
+                                ), f"Field {key} doesn't match after set conversion"
                             break
-                    else:
-                        # If the field isn't in result and we can't find a mapping,
-                        # it might be a field that isn't defined in the model
-                        self.fail(f"Field {key} is missing in the result")
+                        if isinstance(original[key], dict) and isinstance(
+                            result[py_field], dict
+                        ):
+                            compare_json_objects(original[key], result[py_field])
+                        elif isinstance(original[key], list) and isinstance(
+                            result[py_field], list
+                        ):
+                            assert len(original[key]) == len(result[py_field])
+                        else:
+                            assert (
+                                original[key] == result[py_field]
+                            ), f"Field {key} doesn't match"
+                        break
+                else:
+                    # If the field isn't in result, and we can't find a mapping,
+                    # it might be a field that isn't defined in the model
+                    raise Exception(f"Field {key} is missing in the result")
 
-    def _camel_to_snake(self, name):
-        """Convert camelCase to snake_case"""
-        import re
-        s1 = re.sub('(.)([A-Z][a-z]+)', r'\1_\2', name)
-        return re.sub('([a-z0-9])([A-Z])', r'\1_\2', s1).lower()
 
+def camel_to_snake(name):
+    """Convert camelCase to snake_case"""
 
-if __name__ == '__main__':
-    unittest.main()
+    s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()

--- a/tests/serdesertest/test_serdeser_workflow_def.py
+++ b/tests/serdesertest/test_serdeser_workflow_def.py
@@ -1,241 +1,280 @@
-import unittest
 import json
-from conductor.client.http.models import WorkflowDef, WorkflowTask, RateLimit
+
+import pytest
+
+from conductor.client.http.models import RateLimit, WorkflowDef, WorkflowTask
 from conductor.client.http.models.schema_def import SchemaDef
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestWorkflowDefSerDeSer(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("WorkflowDef")
-        self.server_json = json.loads(self.server_json_str)
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("WorkflowDef")
+    return json.loads(server_json_str)
 
-    def test_workflow_def_ser_deser(self):
-        """Test serialization and deserialization of WorkflowDef"""
-        # Print the original JSON structure for debugging
-        # print("Original JSON structure:", json.dumps(self.server_json, indent=2))
 
-        # Step 1: Deserialize JSON to WorkflowDef object
-        # Since direct deserialization has issues with deprecated fields, we'll use the approach
-        # of manual preparation but with improved code structure
-        workflow_def = self._create_workflow_def_from_json(self.server_json)
+def test_workflow_def_ser_deser(server_json):
+    """Test serialization and deserialization of WorkflowDef"""
+    # Print the original JSON structure for debugging
+    # print("Original JSON structure:", json.dumps(self.server_json, indent=2))
+    # Step 1: Deserialize JSON to WorkflowDef object
+    # Since direct deserialization has issues with deprecated fields, we'll use the approach
+    # of manual preparation but with improved code structure
+    workflow_def = create_workflow_def_from_json(server_json)
+    # Step 2: Verify that the object was properly populated
+    verify_fields(workflow_def, server_json)
+    # Step 3: Serialize back to JSON
+    serialized_json = workflow_def.toJSON()
+    # Check if serialized result is already a dictionary (not a JSON string)
+    if not isinstance(serialized_json, dict):
+        serialized_json = json.loads(serialized_json)
+    # Print the serialized structure for debugging
+    # print("Serialized JSON structure:", json.dumps(serialized_json, indent=2))
+    # Step 4: Verify the serialized JSON matches the original for essential properties
+    compare_json(server_json, serialized_json)
 
-        # Step 2: Verify that the object was properly populated
-        self._verify_fields(workflow_def, self.server_json)
 
-        # Step 3: Serialize back to JSON
-        serialized_json = workflow_def.toJSON()
+def create_workflow_def_from_json(json_dict):
+    # Prepare nested objects
+    # 1. Tasks
+    tasks = []
+    if json_dict.get("tasks"):
+        for task_json in json_dict["tasks"]:
+            task = WorkflowTask()
+            # Map task properties
+            if "name" in task_json:
+                task.name = task_json.get("name")
+            if "taskReferenceName" in task_json:
+                task.task_reference_name = task_json.get("taskReferenceName")
+            if "type" in task_json:
+                task.type = task_json.get("type")
+            if "description" in task_json:
+                task.description = task_json.get("description")
+            if "optional" in task_json:
+                task.optional = task_json.get("optional")
+            if "inputParameters" in task_json:
+                task.input_parameters = task_json.get("inputParameters")
+            tasks.append(task)
+    # 2. Input Schema
+    input_schema = None
+    if json_dict.get("inputSchema"):
+        schema_json = json_dict["inputSchema"]
+        input_schema = SchemaDef()
+        if "name" in schema_json:
+            input_schema.name = schema_json.get("name")
+        if "version" in schema_json:
+            input_schema.version = schema_json.get("version")
+    # 3. Output Schema
+    output_schema = None
+    if json_dict.get("outputSchema"):
+        schema_json = json_dict["outputSchema"]
+        output_schema = SchemaDef()
+        if "name" in schema_json:
+            output_schema.name = schema_json.get("name")
+        if "version" in schema_json:
+            output_schema.version = schema_json.get("version")
+    # 4. Rate Limit Config
+    rate_limit_config = None
+    if json_dict.get("rateLimitConfig"):
+        rate_json = json_dict["rateLimitConfig"]
+        rate_limit_config = RateLimit()
+        if "rateLimitKey" in rate_json:
+            rate_limit_config.rate_limit_key = rate_json.get("rateLimitKey")
+        if "concurrentExecLimit" in rate_json:
+            rate_limit_config.concurrent_exec_limit = rate_json.get(
+                "concurrentExecLimit"
+            )
+        if "tag" in rate_json:
+            rate_limit_config.tag = rate_json.get("tag")
+        if "concurrentExecutionLimit" in rate_json:
+            rate_limit_config.concurrent_execution_limit = rate_json.get(
+                "concurrentExecutionLimit"
+            )
+    # Create the WorkflowDef with all parameters
+    workflow_def = WorkflowDef(
+        name=json_dict.get("name"),
+        description=json_dict.get("description"),
+        version=json_dict.get("version"),
+        tasks=tasks,
+        input_parameters=json_dict.get("inputParameters"),
+        output_parameters=json_dict.get("outputParameters", {}),
+        failure_workflow=json_dict.get("failureWorkflow"),
+        schema_version=json_dict.get("schemaVersion"),
+        restartable=json_dict.get("restartable"),
+        workflow_status_listener_enabled=json_dict.get("workflowStatusListenerEnabled"),
+        workflow_status_listener_sink=json_dict.get("workflowStatusListenerSink"),
+        owner_email=json_dict.get("ownerEmail"),
+        timeout_policy=json_dict.get("timeoutPolicy"),
+        timeout_seconds=json_dict.get("timeoutSeconds"),
+        variables=json_dict.get("variables"),
+        input_template=json_dict.get("inputTemplate"),
+        input_schema=input_schema,
+        output_schema=output_schema,
+        enforce_schema=json_dict.get("enforceSchema", False),
+        metadata=json_dict.get("metadata"),
+        rate_limit_config=rate_limit_config,
+        owner_app=json_dict.get("ownerApp"),
+        create_time=json_dict.get("createTime"),
+        update_time=json_dict.get("updateTime"),
+        created_by=json_dict.get("createdBy"),
+        updated_by=json_dict.get("updatedBy"),
+    )
+    return workflow_def
 
-        # Check if serialized result is already a dictionary (not a JSON string)
-        if not isinstance(serialized_json, dict):
-            serialized_json = json.loads(serialized_json)
 
-        # Print the serialized structure for debugging
-        # print("Serialized JSON structure:", json.dumps(serialized_json, indent=2))
-
-        # Step 4: Verify the serialized JSON matches the original for essential properties
-        self._compare_json(self.server_json, serialized_json)
-
-    def _create_workflow_def_from_json(self, json_dict):
-        # Prepare nested objects
-        # 1. Tasks
-        tasks = []
-        if 'tasks' in json_dict and json_dict['tasks']:
-            for task_json in json_dict['tasks']:
-                task = WorkflowTask()
-                # Map task properties
-                if 'name' in task_json:
-                    task.name = task_json.get('name')
-                if 'taskReferenceName' in task_json:
-                    task.task_reference_name = task_json.get('taskReferenceName')
-                if 'type' in task_json:
-                    task.type = task_json.get('type')
-                if 'description' in task_json:
-                    task.description = task_json.get('description')
-                if 'optional' in task_json:
-                    task.optional = task_json.get('optional')
-                if 'inputParameters' in task_json:
-                    task.input_parameters = task_json.get('inputParameters')
-                tasks.append(task)
-
-        # 2. Input Schema
-        input_schema = None
-        if 'inputSchema' in json_dict and json_dict['inputSchema']:
-            schema_json = json_dict['inputSchema']
-            input_schema = SchemaDef()
-            if 'name' in schema_json:
-                input_schema.name = schema_json.get('name')
-            if 'version' in schema_json:
-                input_schema.version = schema_json.get('version')
-
-        # 3. Output Schema
-        output_schema = None
-        if 'outputSchema' in json_dict and json_dict['outputSchema']:
-            schema_json = json_dict['outputSchema']
-            output_schema = SchemaDef()
-            if 'name' in schema_json:
-                output_schema.name = schema_json.get('name')
-            if 'version' in schema_json:
-                output_schema.version = schema_json.get('version')
-
-        # 4. Rate Limit Config
-        rate_limit_config = None
-        if 'rateLimitConfig' in json_dict and json_dict['rateLimitConfig']:
-            rate_json = json_dict['rateLimitConfig']
-            rate_limit_config = RateLimit()
-            if 'rateLimitKey' in rate_json:
-                rate_limit_config.rate_limit_key = rate_json.get('rateLimitKey')
-            if 'concurrentExecLimit' in rate_json:
-                rate_limit_config.concurrent_exec_limit = rate_json.get('concurrentExecLimit')
-            if 'tag' in rate_json:
-                rate_limit_config.tag = rate_json.get('tag')
-            if 'concurrentExecutionLimit' in rate_json:
-                rate_limit_config.concurrent_execution_limit = rate_json.get('concurrentExecutionLimit')
-
-        # Create the WorkflowDef with all parameters
-        workflow_def = WorkflowDef(
-            name=json_dict.get('name'),
-            description=json_dict.get('description'),
-            version=json_dict.get('version'),
-            tasks=tasks,
-            input_parameters=json_dict.get('inputParameters'),
-            output_parameters=json_dict.get('outputParameters', {}),
-            failure_workflow=json_dict.get('failureWorkflow'),
-            schema_version=json_dict.get('schemaVersion'),
-            restartable=json_dict.get('restartable'),
-            workflow_status_listener_enabled=json_dict.get('workflowStatusListenerEnabled'),
-            workflow_status_listener_sink=json_dict.get('workflowStatusListenerSink'),
-            owner_email=json_dict.get('ownerEmail'),
-            timeout_policy=json_dict.get('timeoutPolicy'),
-            timeout_seconds=json_dict.get('timeoutSeconds'),
-            variables=json_dict.get('variables'),
-            input_template=json_dict.get('inputTemplate'),
-            input_schema=input_schema,
-            output_schema=output_schema,
-            enforce_schema=json_dict.get('enforceSchema', False),
-            metadata=json_dict.get('metadata'),
-            rate_limit_config=rate_limit_config,
-            owner_app=json_dict.get('ownerApp'),
-            create_time=json_dict.get('createTime'),
-            update_time=json_dict.get('updateTime'),
-            created_by=json_dict.get('createdBy'),
-            updated_by=json_dict.get('updatedBy')
+def verify_fields(workflow_def, json_dict):
+    """Verify that essential fields were properly populated during deserialization"""
+    # Basic fields
+    assert workflow_def.name == json_dict.get("name")
+    assert workflow_def.description == json_dict.get("description")
+    assert workflow_def.version == json_dict.get("version")
+    assert workflow_def.failure_workflow == json_dict.get("failureWorkflow")
+    assert workflow_def.schema_version == json_dict.get("schemaVersion")
+    assert workflow_def.owner_email == json_dict.get("ownerEmail")
+    assert workflow_def.timeout_seconds == json_dict.get("timeoutSeconds")
+    # Check tasks
+    if json_dict.get("tasks"):
+        assert len(workflow_def.tasks) == len(json_dict.get("tasks", []))
+        # Check first task if available
+        if json_dict["tasks"] and workflow_def.tasks:
+            task_json = json_dict["tasks"][0]
+            task = workflow_def.tasks[0]
+            assert task.name == task_json.get("name")
+            assert task.task_reference_name == task_json.get("taskReferenceName")
+            assert task.type == task_json.get("type")
+    # Check collections
+    if "inputParameters" in json_dict:
+        assert workflow_def.input_parameters == json_dict.get("inputParameters")
+    if "outputParameters" in json_dict:
+        assert workflow_def.output_parameters == json_dict.get("outputParameters")
+    if "variables" in json_dict:
+        assert workflow_def.variables == json_dict.get("variables")
+    if "inputTemplate" in json_dict:
+        assert workflow_def.input_template == json_dict.get("inputTemplate")
+    if "metadata" in json_dict:
+        assert workflow_def.metadata == json_dict.get("metadata")
+    # Check nested objects
+    if "inputSchema" in json_dict and workflow_def.input_schema:
+        input_schema_json = json_dict["inputSchema"]
+        assert workflow_def.input_schema.name == input_schema_json.get("name", None)
+        assert workflow_def.input_schema.version == input_schema_json.get(
+            "version", None
         )
-
-        return workflow_def
-
-    def _verify_fields(self, workflow_def, json_dict):
-        """Verify that essential fields were properly populated during deserialization"""
-        # Basic fields
-        self.assertEqual(workflow_def.name, json_dict.get('name'))
-        self.assertEqual(workflow_def.description, json_dict.get('description'))
-        self.assertEqual(workflow_def.version, json_dict.get('version'))
-        self.assertEqual(workflow_def.failure_workflow, json_dict.get('failureWorkflow'))
-        self.assertEqual(workflow_def.schema_version, json_dict.get('schemaVersion'))
-        self.assertEqual(workflow_def.owner_email, json_dict.get('ownerEmail'))
-        self.assertEqual(workflow_def.timeout_seconds, json_dict.get('timeoutSeconds'))
-
-        # Check tasks
-        if 'tasks' in json_dict and json_dict['tasks']:
-            self.assertEqual(len(workflow_def.tasks), len(json_dict.get('tasks', [])))
-            # Check first task if available
-            if json_dict['tasks'] and workflow_def.tasks:
-                task_json = json_dict['tasks'][0]
-                task = workflow_def.tasks[0]
-                self.assertEqual(task.name, task_json.get('name'))
-                self.assertEqual(task.task_reference_name, task_json.get('taskReferenceName'))
-                self.assertEqual(task.type, task_json.get('type'))
-
-        # Check collections
-        if 'inputParameters' in json_dict:
-            self.assertEqual(workflow_def.input_parameters, json_dict.get('inputParameters'))
-        if 'outputParameters' in json_dict:
-            self.assertEqual(workflow_def.output_parameters, json_dict.get('outputParameters'))
-        if 'variables' in json_dict:
-            self.assertEqual(workflow_def.variables, json_dict.get('variables'))
-        if 'inputTemplate' in json_dict:
-            self.assertEqual(workflow_def.input_template, json_dict.get('inputTemplate'))
-        if 'metadata' in json_dict:
-            self.assertEqual(workflow_def.metadata, json_dict.get('metadata'))
-
-        # Check nested objects
-        if 'inputSchema' in json_dict and workflow_def.input_schema:
-            input_schema_json = json_dict['inputSchema']
-            self.assertEqual(workflow_def.input_schema.name, input_schema_json.get('name', None))
-            self.assertEqual(workflow_def.input_schema.version, input_schema_json.get('version', None))
-
-        if 'outputSchema' in json_dict and workflow_def.output_schema:
-            output_schema_json = json_dict['outputSchema']
-            self.assertEqual(workflow_def.output_schema.name, output_schema_json.get('name', None))
-            self.assertEqual(workflow_def.output_schema.version, output_schema_json.get('version', None))
-
-        if 'rateLimitConfig' in json_dict and workflow_def.rate_limit_config:
-            rate_json = json_dict['rateLimitConfig']
-            self.assertEqual(workflow_def.rate_limit_config.rate_limit_key, rate_json.get('rateLimitKey', None))
-            self.assertEqual(workflow_def.rate_limit_config.concurrent_exec_limit,
-                             rate_json.get('concurrentExecLimit', None))
-
-        # Check enum values
-        if 'timeoutPolicy' in json_dict:
-            self.assertEqual(workflow_def.timeout_policy, json_dict.get('timeoutPolicy'))
-            self.assertIn(workflow_def.timeout_policy, ["TIME_OUT_WF", "ALERT_ONLY"])
-
-        # Check booleans
-        if 'restartable' in json_dict:
-            self.assertEqual(workflow_def.restartable, json_dict.get('restartable'))
-        if 'workflowStatusListenerEnabled' in json_dict:
-            self.assertEqual(workflow_def.workflow_status_listener_enabled,
-                             json_dict.get('workflowStatusListenerEnabled'))
-        if 'enforceSchema' in json_dict:
-            self.assertEqual(workflow_def.enforce_schema, json_dict.get('enforceSchema', False))
-
-    def _compare_json(self, original, serialized):
-        """Compare essential properties between original and serialized JSON"""
-        # Keys to skip in comparison (template-specific or not part of the model)
-        keys_to_skip = {
-            # Template fields not in the model
-            'data', 'type', 'categories', 'references', 'properties', 'items',
-            'defaultTask', 'format', 'required', 'externalRef', 'joinOn',
-            'scriptExpression', 'cacheConfig', 'decisionCases', 'loopOver',
-            'caseExpression', 'defaultExclusiveJoinTask', 'taskDefinition',
-            'caseValueParam', 'dynamicForkTasksInputParamName', 'expression',
-            'loopCondition', 'asyncComplete', 'sink', 'rateLimited', 'retryCount',
-            'subWorkflowParam', 'joinStatus', 'evaluatorType', 'dynamicTaskNameParam',
-            'startDelay', 'permissive', 'defaultCase', 'forkTasks', 'dynamicForkTasksParam',
-            'onStateChange', 'dynamicForkJoinTasksParam',
-
-            # Deprecated fields
-            'ownerApp', 'createTime', 'updateTime', 'createdBy', 'updatedBy'
-        }
-
-        # Check essential keys
-        essential_keys = {
-            'name', 'description', 'version', 'failureWorkflow', 'schemaVersion',
-            'restartable', 'workflowStatusListenerEnabled', 'workflowStatusListenerSink',
-            'ownerEmail', 'timeoutPolicy', 'timeoutSeconds'
-        }
-
-        for key in essential_keys:
-            if key in original and original[key] is not None:
-                self.assertIn(key, serialized, f"Essential key {key} missing in serialized JSON")
-                self.assertEqual(original[key], serialized[key], f"Value mismatch for key {key}")
-
-        # Check complex structures if they exist
-        if 'tasks' in original and original['tasks'] and 'tasks' in serialized and serialized['tasks']:
-            # Check that tasks array exists and has at least one item
-            self.assertTrue(len(serialized['tasks']) > 0, "Tasks array should not be empty")
-
-            # Check first task properties
-            original_task = original['tasks'][0]
-            serialized_task = serialized['tasks'][0]
-
-            task_essential_keys = {'name', 'taskReferenceName', 'type'}
-            for key in task_essential_keys:
-                if key in original_task and original_task[key] is not None:
-                    self.assertIn(key, serialized_task, f"Essential task key {key} missing")
-                    self.assertEqual(original_task[key], serialized_task[key], f"Task value mismatch for {key}")
+    if "outputSchema" in json_dict and workflow_def.output_schema:
+        output_schema_json = json_dict["outputSchema"]
+        assert workflow_def.output_schema.name == output_schema_json.get("name", None)
+        assert workflow_def.output_schema.version == output_schema_json.get(
+            "version", None
+        )
+    if "rateLimitConfig" in json_dict and workflow_def.rate_limit_config:
+        rate_json = json_dict["rateLimitConfig"]
+        assert workflow_def.rate_limit_config.rate_limit_key == rate_json.get(
+            "rateLimitKey", None
+        )
+        assert workflow_def.rate_limit_config.concurrent_exec_limit == rate_json.get(
+            "concurrentExecLimit", None
+        )
+    # Check enum values
+    if "timeoutPolicy" in json_dict:
+        assert workflow_def.timeout_policy == json_dict.get("timeoutPolicy")
+        assert workflow_def.timeout_policy in ["TIME_OUT_WF", "ALERT_ONLY"]
+    # Check booleans
+    if "restartable" in json_dict:
+        assert workflow_def.restartable == json_dict.get("restartable")
+    if "workflowStatusListenerEnabled" in json_dict:
+        assert workflow_def.workflow_status_listener_enabled == json_dict.get(
+            "workflowStatusListenerEnabled"
+        )
+    if "enforceSchema" in json_dict:
+        assert workflow_def.enforce_schema == json_dict.get("enforceSchema", False)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def compare_json(original, serialized):
+    """Compare essential properties between original and serialized JSON"""
+    # Keys to skip in comparison (template-specific or not part of the model)
+    keys_to_skip = {  # noqa: F841
+        # Template fields not in the model
+        "data",
+        "type",
+        "categories",
+        "references",
+        "properties",
+        "items",
+        "defaultTask",
+        "format",
+        "required",
+        "externalRef",
+        "joinOn",
+        "scriptExpression",
+        "cacheConfig",
+        "decisionCases",
+        "loopOver",
+        "caseExpression",
+        "defaultExclusiveJoinTask",
+        "taskDefinition",
+        "caseValueParam",
+        "dynamicForkTasksInputParamName",
+        "expression",
+        "loopCondition",
+        "asyncComplete",
+        "sink",
+        "rateLimited",
+        "retryCount",
+        "subWorkflowParam",
+        "joinStatus",
+        "evaluatorType",
+        "dynamicTaskNameParam",
+        "startDelay",
+        "permissive",
+        "defaultCase",
+        "forkTasks",
+        "dynamicForkTasksParam",
+        "onStateChange",
+        "dynamicForkJoinTasksParam",
+        # Deprecated fields
+        "ownerApp",
+        "createTime",
+        "updateTime",
+        "createdBy",
+        "updatedBy",
+    }
+    # Check essential keys
+    essential_keys = {
+        "name",
+        "description",
+        "version",
+        "failureWorkflow",
+        "schemaVersion",
+        "restartable",
+        "workflowStatusListenerEnabled",
+        "workflowStatusListenerSink",
+        "ownerEmail",
+        "timeoutPolicy",
+        "timeoutSeconds",
+    }
+    for key in essential_keys:
+        if key in original and original[key] is not None:
+            assert key in serialized, f"Essential key {key} missing in serialized JSON"
+
+            assert original[key] == serialized[key], f"Value mismatch for key {key}"
+    # Check complex structures if they exist
+    if (
+        "tasks" in original
+        and original["tasks"]
+        and "tasks" in serialized
+        and serialized["tasks"]
+    ):
+        # Check that tasks array exists and has at least one item
+        assert len(serialized["tasks"]) > 0, "Tasks array should not be empty"
+
+        # Check first task properties
+        original_task = original["tasks"][0]
+        serialized_task = serialized["tasks"][0]
+        task_essential_keys = {"name", "taskReferenceName", "type"}
+        for key in task_essential_keys:
+            if key in original_task and original_task[key] is not None:
+                assert key in serialized_task, f"Essential task key {key} missing"
+
+                assert (
+                    original_task[key] == serialized_task[key]
+                ), f"Task value mismatch for {key}"

--- a/tests/serdesertest/test_serdeser_workflow_schedule.py
+++ b/tests/serdesertest/test_serdeser_workflow_schedule.py
@@ -1,148 +1,144 @@
-import unittest
-from conductor.client.http.models.workflow_schedule import WorkflowSchedule
-from conductor.client.http.models.start_workflow_request import StartWorkflowRequest
-from conductor.client.http.models.tag_object import TagObject
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 import json
 
+import pytest
 
-class TestWorkflowScheduleSerialization(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("WorkflowSchedule")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_workflow_schedule_serialization(self):
-        # 1. Test deserialization from server JSON to SDK model
-        schedule = WorkflowSchedule(
-            name=self.server_json.get('name'),
-            cron_expression=self.server_json.get('cronExpression'),
-            run_catchup_schedule_instances=self.server_json.get('runCatchupScheduleInstances'),
-            paused=self.server_json.get('paused'),
-            schedule_start_time=self.server_json.get('scheduleStartTime'),
-            schedule_end_time=self.server_json.get('scheduleEndTime'),
-            create_time=self.server_json.get('createTime'),
-            updated_time=self.server_json.get('updatedTime'),
-            created_by=self.server_json.get('createdBy'),
-            updated_by=self.server_json.get('updatedBy'),
-            zone_id=self.server_json.get('zoneId'),
-            paused_reason=self.server_json.get('pausedReason'),
-            description=self.server_json.get('description')
-        )
-
-        # Process special fields that require conversion: startWorkflowRequest and tags
-        if 'startWorkflowRequest' in self.server_json:
-            start_req_json = self.server_json.get('startWorkflowRequest')
-            if start_req_json:
-                start_req = StartWorkflowRequest(
-                    name=start_req_json.get('name'),
-                    version=start_req_json.get('version'),
-                    correlation_id=start_req_json.get('correlationId'),
-                    input=start_req_json.get('input')
-                )
-                schedule.start_workflow_request = start_req
-
-        if 'tags' in self.server_json:
-            tags_json = self.server_json.get('tags')
-            if tags_json:
-                tags = []
-                for tag_json in tags_json:
-                    tag = TagObject(
-                        key=tag_json.get('key'),
-                        value=tag_json.get('value')
-                    )
-                    tags.append(tag)
-                schedule.tags = tags
-
-        # 2. Verify all fields are properly populated
-        self._verify_all_fields(schedule, self.server_json)
-
-        # 3. Test serialization back to JSON
-        serialized_json = schedule.to_dict()
-
-        # 4. Verify the serialized JSON matches the original
-        self._verify_json_match(serialized_json, self.server_json)
-
-    def _verify_all_fields(self, schedule, json_data):
-        # Verify simple fields
-        self.assertEqual(schedule.name, json_data.get('name'))
-        self.assertEqual(schedule.cron_expression, json_data.get('cronExpression'))
-        self.assertEqual(schedule.run_catchup_schedule_instances, json_data.get('runCatchupScheduleInstances'))
-        self.assertEqual(schedule.paused, json_data.get('paused'))
-        self.assertEqual(schedule.schedule_start_time, json_data.get('scheduleStartTime'))
-        self.assertEqual(schedule.schedule_end_time, json_data.get('scheduleEndTime'))
-        self.assertEqual(schedule.create_time, json_data.get('createTime'))
-        self.assertEqual(schedule.updated_time, json_data.get('updatedTime'))
-        self.assertEqual(schedule.created_by, json_data.get('createdBy'))
-        self.assertEqual(schedule.updated_by, json_data.get('updatedBy'))
-        self.assertEqual(schedule.zone_id, json_data.get('zoneId'))
-        self.assertEqual(schedule.paused_reason, json_data.get('pausedReason'))
-        self.assertEqual(schedule.description, json_data.get('description'))
-
-        # Verify StartWorkflowRequest
-        if 'startWorkflowRequest' in json_data and json_data['startWorkflowRequest'] is not None:
-            start_req_json = json_data['startWorkflowRequest']
-            start_req = schedule.start_workflow_request
-
-            self.assertIsNotNone(start_req)
-            self.assertEqual(start_req.name, start_req_json.get('name'))
-            self.assertEqual(start_req.version, start_req_json.get('version'))
-            self.assertEqual(start_req.correlation_id, start_req_json.get('correlationId'))
-            self.assertEqual(start_req.input, start_req_json.get('input'))
-
-        # Verify Tags
-        if 'tags' in json_data and json_data['tags'] is not None:
-            tags_json = json_data['tags']
-            tags = schedule.tags
-
-            self.assertIsNotNone(tags)
-            self.assertEqual(len(tags), len(tags_json))
-
-            for i, tag_json in enumerate(tags_json):
-                tag = tags[i]
-                self.assertEqual(tag.key, tag_json.get('key'))
-                self.assertEqual(tag.value, tag_json.get('value'))
-
-    def _verify_json_match(self, serialized_json, original_json):
-        # Check field by field to handle camelCase to snake_case conversion
-        self.assertEqual(serialized_json.get('name'), original_json.get('name'))
-        self.assertEqual(serialized_json.get('cron_expression'), original_json.get('cronExpression'))
-        self.assertEqual(serialized_json.get('run_catchup_schedule_instances'),
-                         original_json.get('runCatchupScheduleInstances'))
-        self.assertEqual(serialized_json.get('paused'), original_json.get('paused'))
-        self.assertEqual(serialized_json.get('schedule_start_time'), original_json.get('scheduleStartTime'))
-        self.assertEqual(serialized_json.get('schedule_end_time'), original_json.get('scheduleEndTime'))
-        self.assertEqual(serialized_json.get('create_time'), original_json.get('createTime'))
-        self.assertEqual(serialized_json.get('updated_time'), original_json.get('updatedTime'))
-        self.assertEqual(serialized_json.get('created_by'), original_json.get('createdBy'))
-        self.assertEqual(serialized_json.get('updated_by'), original_json.get('updatedBy'))
-        self.assertEqual(serialized_json.get('zone_id'), original_json.get('zoneId'))
-        self.assertEqual(serialized_json.get('paused_reason'), original_json.get('pausedReason'))
-        self.assertEqual(serialized_json.get('description'), original_json.get('description'))
-
-        # Check StartWorkflowRequest
-        if 'startWorkflowRequest' in original_json and original_json['startWorkflowRequest'] is not None:
-            orig_req = original_json['startWorkflowRequest']
-            serial_req = serialized_json.get('start_workflow_request')
-
-            self.assertIsNotNone(serial_req)
-            self.assertEqual(serial_req.get('name'), orig_req.get('name'))
-            self.assertEqual(serial_req.get('version'), orig_req.get('version'))
-            self.assertEqual(serial_req.get('correlation_id'), orig_req.get('correlationId'))
-            self.assertEqual(serial_req.get('input'), orig_req.get('input'))
-
-        # Check Tags
-        if 'tags' in original_json and original_json['tags'] is not None:
-            orig_tags = original_json['tags']
-            serial_tags = serialized_json.get('tags')
-
-            self.assertIsNotNone(serial_tags)
-            self.assertEqual(len(serial_tags), len(orig_tags))
-
-            for i, orig_tag in enumerate(orig_tags):
-                serial_tag = serial_tags[i]
-                self.assertEqual(serial_tag.get('key'), orig_tag.get('key'))
-                self.assertEqual(serial_tag.get('value'), orig_tag.get('value'))
+from conductor.client.http.models.start_workflow_request import StartWorkflowRequest
+from conductor.client.http.models.tag_object import TagObject
+from conductor.client.http.models.workflow_schedule import WorkflowSchedule
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("WorkflowSchedule")
+    return json.loads(server_json_str)
+
+
+def test_workflow_schedule_serialization(server_json):
+    # 1. Test deserialization from server JSON to SDK model
+    schedule = WorkflowSchedule(
+        name=server_json.get("name"),
+        cron_expression=server_json.get("cronExpression"),
+        run_catchup_schedule_instances=server_json.get("runCatchupScheduleInstances"),
+        paused=server_json.get("paused"),
+        schedule_start_time=server_json.get("scheduleStartTime"),
+        schedule_end_time=server_json.get("scheduleEndTime"),
+        create_time=server_json.get("createTime"),
+        updated_time=server_json.get("updatedTime"),
+        created_by=server_json.get("createdBy"),
+        updated_by=server_json.get("updatedBy"),
+        zone_id=server_json.get("zoneId"),
+        paused_reason=server_json.get("pausedReason"),
+        description=server_json.get("description"),
+    )
+    # Process special fields that require conversion: startWorkflowRequest and tags
+    if "startWorkflowRequest" in server_json:
+        start_req_json = server_json.get("startWorkflowRequest")
+        if start_req_json:
+            start_req = StartWorkflowRequest(
+                name=start_req_json.get("name"),
+                version=start_req_json.get("version"),
+                correlation_id=start_req_json.get("correlationId"),
+                input=start_req_json.get("input"),
+            )
+            schedule.start_workflow_request = start_req
+    if "tags" in server_json:
+        tags_json = server_json.get("tags")
+        if tags_json:
+            tags = []
+            for tag_json in tags_json:
+                tag = TagObject(key=tag_json.get("key"), value=tag_json.get("value"))
+                tags.append(tag)
+            schedule.tags = tags
+    # 2. Verify all fields are properly populated
+    _verify_all_fields(schedule, server_json)
+    # 3. Test serialization back to JSON
+    serialized_json = schedule.to_dict()
+    # 4. Verify the serialized JSON matches the original
+    _verify_json_match(serialized_json, server_json)
+
+
+def _verify_all_fields(schedule, json_data):
+    # Verify simple fields
+    assert schedule.name == json_data.get("name")
+    assert schedule.cron_expression == json_data.get("cronExpression")
+    assert schedule.run_catchup_schedule_instances == json_data.get(
+        "runCatchupScheduleInstances"
+    )
+    assert schedule.paused == json_data.get("paused")
+    assert schedule.schedule_start_time == json_data.get("scheduleStartTime")
+    assert schedule.schedule_end_time == json_data.get("scheduleEndTime")
+    assert schedule.create_time == json_data.get("createTime")
+    assert schedule.updated_time == json_data.get("updatedTime")
+    assert schedule.created_by == json_data.get("createdBy")
+    assert schedule.updated_by == json_data.get("updatedBy")
+    assert schedule.zone_id == json_data.get("zoneId")
+    assert schedule.paused_reason == json_data.get("pausedReason")
+    assert schedule.description == json_data.get("description")
+    # Verify StartWorkflowRequest
+    if (
+        "startWorkflowRequest" in json_data
+        and json_data["startWorkflowRequest"] is not None
+    ):
+        start_req_json = json_data["startWorkflowRequest"]
+        start_req = schedule.start_workflow_request
+        assert start_req
+        assert start_req.name == start_req_json.get("name")
+        assert start_req.version == start_req_json.get("version")
+        assert start_req.correlation_id == start_req_json.get("correlationId")
+        assert start_req.input == start_req_json.get("input")
+    # Verify Tags
+    if "tags" in json_data and json_data["tags"] is not None:
+        tags_json = json_data["tags"]
+        tags = schedule.tags
+        assert tags
+        assert len(tags) == len(tags_json)
+        for i, tag_json in enumerate(tags_json):
+            tag = tags[i]
+            assert tag.key == tag_json.get("key")
+            assert tag.value == tag_json.get("value")
+
+
+def _verify_json_match(serialized_json, original_json):
+    # Check field by field to handle camelCase to snake_case conversion
+    assert serialized_json.get("name") == original_json.get("name")
+    assert serialized_json.get("cron_expression") == original_json.get("cronExpression")
+    assert serialized_json.get("run_catchup_schedule_instances") == original_json.get(
+        "runCatchupScheduleInstances"
+    )
+    assert serialized_json.get("paused") == original_json.get("paused")
+    assert serialized_json.get("schedule_start_time") == original_json.get(
+        "scheduleStartTime"
+    )
+    assert serialized_json.get("schedule_end_time") == original_json.get(
+        "scheduleEndTime"
+    )
+    assert serialized_json.get("create_time") == original_json.get("createTime")
+    assert serialized_json.get("updated_time") == original_json.get("updatedTime")
+    assert serialized_json.get("created_by") == original_json.get("createdBy")
+    assert serialized_json.get("updated_by") == original_json.get("updatedBy")
+    assert serialized_json.get("zone_id") == original_json.get("zoneId")
+    assert serialized_json.get("paused_reason") == original_json.get("pausedReason")
+    assert serialized_json.get("description") == original_json.get("description")
+    # Check StartWorkflowRequest
+    if (
+        "startWorkflowRequest" in original_json
+        and original_json["startWorkflowRequest"] is not None
+    ):
+        orig_req = original_json["startWorkflowRequest"]
+        serial_req = serialized_json.get("start_workflow_request")
+        assert serial_req
+        assert serial_req.get("name") == orig_req.get("name")
+        assert serial_req.get("version") == orig_req.get("version")
+        assert serial_req.get("correlation_id") == orig_req.get("correlationId")
+        assert serial_req.get("input") == orig_req.get("input")
+    # Check Tags
+    if "tags" in original_json and original_json["tags"] is not None:
+        orig_tags = original_json["tags"]
+        serial_tags = serialized_json.get("tags")
+        assert serial_tags
+        assert len(serial_tags) == len(orig_tags)
+        for i, orig_tag in enumerate(orig_tags):
+            serial_tag = serial_tags[i]
+            assert serial_tag.get("key") == orig_tag.get("key")
+            assert serial_tag.get("value") == orig_tag.get("value")

--- a/tests/serdesertest/test_serdeser_workflow_schedule_execution_model.py
+++ b/tests/serdesertest/test_serdeser_workflow_schedule_execution_model.py
@@ -1,72 +1,73 @@
-import unittest
 import json
-from conductor.client.http.models.workflow_schedule_execution_model import WorkflowScheduleExecutionModel
+
+import pytest
+
+from conductor.client.http.models.workflow_schedule_execution_model import (
+    WorkflowScheduleExecutionModel,
+)
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestWorkflowScheduleExecutionModelSerDes(unittest.TestCase):
-    def setUp(self):
-        # Load the JSON template
-        self.server_json_str = JsonTemplateResolver.get_json_string("WorkflowScheduleExecutionModel")
-        self.server_json = json.loads(self.server_json_str)
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string(
+        "WorkflowScheduleExecutionModel"
+    )
+    return json.loads(server_json_str)
 
-    def test_workflow_schedule_execution_model_serdes(self):
-        # 1. Deserialize JSON into model object
-        model = WorkflowScheduleExecutionModel(
-            execution_id=self.server_json.get('executionId'),
-            schedule_name=self.server_json.get('scheduleName'),
-            scheduled_time=self.server_json.get('scheduledTime'),
-            execution_time=self.server_json.get('executionTime'),
-            workflow_name=self.server_json.get('workflowName'),
-            workflow_id=self.server_json.get('workflowId'),
-            reason=self.server_json.get('reason'),
-            stack_trace=self.server_json.get('stackTrace'),
-            start_workflow_request=self.server_json.get('startWorkflowRequest'),
-            state=self.server_json.get('state'),
-            zone_id=self.server_json.get('zoneId'),
-            org_id=self.server_json.get('orgId')
+
+def test_workflow_schedule_execution_model_serdes(server_json):
+    # 1. Deserialize JSON into model object
+    model = WorkflowScheduleExecutionModel(
+        execution_id=server_json.get("executionId"),
+        schedule_name=server_json.get("scheduleName"),
+        scheduled_time=server_json.get("scheduledTime"),
+        execution_time=server_json.get("executionTime"),
+        workflow_name=server_json.get("workflowName"),
+        workflow_id=server_json.get("workflowId"),
+        reason=server_json.get("reason"),
+        stack_trace=server_json.get("stackTrace"),
+        start_workflow_request=server_json.get("startWorkflowRequest"),
+        state=server_json.get("state"),
+        zone_id=server_json.get("zoneId"),
+        org_id=server_json.get("orgId"),
+    )
+    # 2. Verify all fields are properly populated
+    assert model.execution_id == server_json.get("executionId")
+    assert model.schedule_name == server_json.get("scheduleName")
+    assert model.scheduled_time == server_json.get("scheduledTime")
+    assert model.execution_time == server_json.get("executionTime")
+    assert model.workflow_name == server_json.get("workflowName")
+    assert model.workflow_id == server_json.get("workflowId")
+    assert model.reason == server_json.get("reason")
+    assert model.stack_trace == server_json.get("stackTrace")
+    assert model.start_workflow_request == server_json.get("startWorkflowRequest")
+    assert model.state == server_json.get("state")
+    assert model.zone_id == server_json.get("zoneId")
+    assert model.org_id == server_json.get("orgId")
+    # Check that enum values are correctly handled
+    if model.state:
+        assert model.state in ["POLLED", "FAILED", "EXECUTED"]
+    # 3. Serialize model back to dict
+    model_dict = model.to_dict()
+    # 4. Compare with original JSON to ensure no data loss
+    # Handle camelCase to snake_case transformations
+    assert model_dict.get("execution_id") == server_json.get("executionId")
+    assert model_dict.get("schedule_name") == server_json.get("scheduleName")
+    assert model_dict.get("scheduled_time") == server_json.get("scheduledTime")
+    assert model_dict.get("execution_time") == server_json.get("executionTime")
+    assert model_dict.get("workflow_name") == server_json.get("workflowName")
+    assert model_dict.get("workflow_id") == server_json.get("workflowId")
+    assert model_dict.get("reason") == server_json.get("reason")
+    assert model_dict.get("stack_trace") == server_json.get("stackTrace")
+    assert model_dict.get("start_workflow_request") == server_json.get(
+        "startWorkflowRequest"
+    )
+    assert model_dict.get("state") == server_json.get("state")
+    assert model_dict.get("zone_id") == server_json.get("zoneId")
+    assert model_dict.get("org_id") == server_json.get("orgId")
+    # Additional validation for complex structures (if any were present)
+    if isinstance(model.start_workflow_request, dict):
+        assert model_dict.get("start_workflow_request") == server_json.get(
+            "startWorkflowRequest"
         )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(model.execution_id, self.server_json.get('executionId'))
-        self.assertEqual(model.schedule_name, self.server_json.get('scheduleName'))
-        self.assertEqual(model.scheduled_time, self.server_json.get('scheduledTime'))
-        self.assertEqual(model.execution_time, self.server_json.get('executionTime'))
-        self.assertEqual(model.workflow_name, self.server_json.get('workflowName'))
-        self.assertEqual(model.workflow_id, self.server_json.get('workflowId'))
-        self.assertEqual(model.reason, self.server_json.get('reason'))
-        self.assertEqual(model.stack_trace, self.server_json.get('stackTrace'))
-        self.assertEqual(model.start_workflow_request, self.server_json.get('startWorkflowRequest'))
-        self.assertEqual(model.state, self.server_json.get('state'))
-        self.assertEqual(model.zone_id, self.server_json.get('zoneId'))
-        self.assertEqual(model.org_id, self.server_json.get('orgId'))
-
-        # Check that enum values are correctly handled
-        if model.state:
-            self.assertIn(model.state, ["POLLED", "FAILED", "EXECUTED"])
-
-        # 3. Serialize model back to dict
-        model_dict = model.to_dict()
-
-        # 4. Compare with original JSON to ensure no data loss
-        # Handle camelCase to snake_case transformations
-        self.assertEqual(model_dict.get('execution_id'), self.server_json.get('executionId'))
-        self.assertEqual(model_dict.get('schedule_name'), self.server_json.get('scheduleName'))
-        self.assertEqual(model_dict.get('scheduled_time'), self.server_json.get('scheduledTime'))
-        self.assertEqual(model_dict.get('execution_time'), self.server_json.get('executionTime'))
-        self.assertEqual(model_dict.get('workflow_name'), self.server_json.get('workflowName'))
-        self.assertEqual(model_dict.get('workflow_id'), self.server_json.get('workflowId'))
-        self.assertEqual(model_dict.get('reason'), self.server_json.get('reason'))
-        self.assertEqual(model_dict.get('stack_trace'), self.server_json.get('stackTrace'))
-        self.assertEqual(model_dict.get('start_workflow_request'), self.server_json.get('startWorkflowRequest'))
-        self.assertEqual(model_dict.get('state'), self.server_json.get('state'))
-        self.assertEqual(model_dict.get('zone_id'), self.server_json.get('zoneId'))
-        self.assertEqual(model_dict.get('org_id'), self.server_json.get('orgId'))
-
-        # Additional validation for complex structures (if any were present)
-        if isinstance(model.start_workflow_request, dict):
-            self.assertEqual(model_dict.get('start_workflow_request'), self.server_json.get('startWorkflowRequest'))
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/serdesertest/test_serdeser_workflow_state_update.py
+++ b/tests/serdesertest/test_serdeser_workflow_state_update.py
@@ -1,207 +1,231 @@
-import unittest
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
-from conductor.client.http.models import WorkflowStateUpdate, TaskResult, TaskExecLog, TaskResultStatus
 import json
 
+import pytest
 
-class TestWorkflowStateUpdate(unittest.TestCase):
-    def setUp(self):
-        # Load JSON template using JsonTemplateResolver
-        self.server_json_str = JsonTemplateResolver.get_json_string("WorkflowStateUpdate")
-        self.server_json = json.loads(self.server_json_str)
+from conductor.client.http.models import (
+    TaskExecLog,
+    TaskResult,
+    TaskResultStatus,
+    WorkflowStateUpdate,
+)
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
-    def test_serialization_deserialization(self):
-        # Step 1: Deserialize JSON to SDK model object
 
-        # First, properly initialize TaskResult if it exists
-        task_result_json = self.server_json.get("taskResult")
-        task_result = None
-        if task_result_json:
-            # Create TaskExecLog objects if logs are present
-            logs = []
-            if task_result_json.get("logs"):
-                for log_entry in task_result_json.get("logs"):
-                    logs.append(TaskExecLog(
-                        log=log_entry.get("log"),
-                        created_time=log_entry.get("createdTime"),
-                        task_id=log_entry.get("taskId")
-                    ))
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("WorkflowStateUpdate")
+    return json.loads(server_json_str)
 
-            # Create TaskResult object with proper field mappings
-            task_result = TaskResult(
-                workflow_instance_id=task_result_json.get("workflowInstanceId"),
-                task_id=task_result_json.get("taskId"),
-                reason_for_incompletion=task_result_json.get("reasonForIncompletion"),
-                callback_after_seconds=task_result_json.get("callbackAfterSeconds"),
-                worker_id=task_result_json.get("workerId"),
-                status=task_result_json.get("status"),
-                output_data=task_result_json.get("outputData"),
-                logs=logs,
-                external_output_payload_storage_path=task_result_json.get("externalOutputPayloadStoragePath"),
-                sub_workflow_id=task_result_json.get("subWorkflowId"),
-                extend_lease=task_result_json.get("extendLease")
-            )
 
-        # Now create the WorkflowStateUpdate object
-        model_object = WorkflowStateUpdate(
-            task_reference_name=self.server_json.get("taskReferenceName"),
-            task_result=task_result,
-            variables=self.server_json.get("variables")
+def test_serialization_deserialization(server_json):  # noqa: PLR0915
+    # Step 1: Deserialize JSON to SDK model object
+    # First, properly initialize TaskResult if it exists
+    task_result_json = server_json.get("taskResult")
+    task_result = None
+    if task_result_json:
+        # Create TaskExecLog objects if logs are present
+        logs = (
+            [
+                TaskExecLog(
+                    log=log_entry.get("log"),
+                    created_time=log_entry.get("createdTime"),
+                    task_id=log_entry.get("taskId"),
+                )
+                for log_entry in task_result_json.get("logs")
+            ]
+            if task_result_json.get("logs")
+            else []
         )
 
-        # Step 2: Verify all fields are properly populated
-        self.assertEqual(model_object.task_reference_name, self.server_json.get("taskReferenceName"))
-
-        if task_result_json:
-            # Verify TaskResult fields
-            self.assertIsNotNone(model_object.task_result)
-
-            # Check each field that exists in the JSON
-            for json_key, python_attr in TaskResult.attribute_map.items():
-                if python_attr in task_result_json:
-                    # Special handling for status field which is converted to enum
-                    if json_key == "status" and task_result_json.get("status"):
-                        self.assertEqual(model_object.task_result.status.name, task_result_json.get("status"))
-                    # Special handling for logs which are objects
-                    elif json_key == "logs" and task_result_json.get("logs"):
-                        self.assertEqual(len(model_object.task_result.logs), len(task_result_json.get("logs")))
-                        for i, log in enumerate(model_object.task_result.logs):
-                            json_log = task_result_json.get("logs")[i]
-                            if "log" in json_log:
-                                self.assertEqual(log.log, json_log.get("log"))
-                            if "createdTime" in json_log:
-                                self.assertEqual(log.created_time, json_log.get("createdTime"))
-                            if "taskId" in json_log:
-                                self.assertEqual(log.task_id, json_log.get("taskId"))
-                    # Normal field comparison
-                    else:
-                        python_field_value = getattr(model_object.task_result, json_key)
-                        json_field_value = task_result_json.get(python_attr)
-                        self.assertEqual(python_field_value, json_field_value)
-
-        if self.server_json.get("variables"):
-            self.assertEqual(model_object.variables, self.server_json.get("variables"))
-
-        # Step 3: Serialize the model back to dict
-        result_dict = model_object.to_dict()
-
-        # Step 4: Convert result_dict to match the original JSON structure
-        serialized_json = {}
-
-        # Map snake_case keys to camelCase based on attribute_map
-        for snake_key, camel_key in WorkflowStateUpdate.attribute_map.items():
-            if snake_key in result_dict and result_dict[snake_key] is not None:
-                if snake_key == "task_result" and result_dict[snake_key]:
-                    # Handle TaskResult conversion
-                    task_result_dict = result_dict[snake_key]
-                    serialized_task_result = {}
-
-                    # Map TaskResult fields using its attribute_map
-                    for tr_snake_key, tr_camel_key in TaskResult.attribute_map.items():
-                        if tr_snake_key in task_result_dict and task_result_dict[tr_snake_key] is not None:
-                            # Special handling for status which could be an enum
-                            if tr_snake_key == "status" and isinstance(task_result_dict[tr_snake_key],
-                                                                       TaskResultStatus):
-                                serialized_task_result[tr_camel_key] = task_result_dict[tr_snake_key].name
-                            # Special handling for logs which are objects
-                            elif tr_snake_key == "logs" and task_result_dict[tr_snake_key]:
-                                serialized_logs = []
-                                for log in task_result_dict[tr_snake_key]:
-                                    if hasattr(log, "to_dict"):
-                                        log_dict = log.to_dict()
-                                        # Convert log dict keys to camelCase
-                                        serialized_log = {}
-                                        for log_key, log_value in log_dict.items():
-                                            if hasattr(TaskExecLog,
-                                                       "attribute_map") and log_key in TaskExecLog.attribute_map:
-                                                serialized_log[TaskExecLog.attribute_map[log_key]] = log_value
-                                            else:
-                                                serialized_log[log_key] = log_value
-                                        serialized_logs.append(serialized_log)
-                                    else:
-                                        serialized_logs.append(log)
-                                serialized_task_result[tr_camel_key] = serialized_logs
-                            else:
-                                serialized_task_result[tr_camel_key] = task_result_dict[tr_snake_key]
-
-                    serialized_json[camel_key] = serialized_task_result
+        # Create TaskResult object with proper field mappings
+        task_result = TaskResult(
+            workflow_instance_id=task_result_json.get("workflowInstanceId"),
+            task_id=task_result_json.get("taskId"),
+            reason_for_incompletion=task_result_json.get("reasonForIncompletion"),
+            callback_after_seconds=task_result_json.get("callbackAfterSeconds"),
+            worker_id=task_result_json.get("workerId"),
+            status=task_result_json.get("status"),
+            output_data=task_result_json.get("outputData"),
+            logs=logs,
+            external_output_payload_storage_path=task_result_json.get(
+                "externalOutputPayloadStoragePath"
+            ),
+            sub_workflow_id=task_result_json.get("subWorkflowId"),
+            extend_lease=task_result_json.get("extendLease"),
+        )
+    # Now create the WorkflowStateUpdate object
+    model_object = WorkflowStateUpdate(
+        task_reference_name=server_json.get("taskReferenceName"),
+        task_result=task_result,
+        variables=server_json.get("variables"),
+    )
+    # Step 2: Verify all fields are properly populated
+    assert model_object.task_reference_name == server_json.get("taskReferenceName")
+    if task_result_json:
+        # Verify TaskResult fields
+        assert model_object.task_result is not None
+        # Check each field that exists in the JSON
+        for json_key, python_attr in TaskResult.attribute_map.items():
+            if python_attr in task_result_json:
+                # Special handling for status field which is converted to enum
+                if json_key == "status" and task_result_json.get("status"):
+                    assert model_object.task_result.status.name == task_result_json.get(
+                        "status"
+                    )
+                # Special handling for logs which are objects
+                elif json_key == "logs" and task_result_json.get("logs"):
+                    assert len(model_object.task_result.logs) == len(
+                        task_result_json.get("logs")
+                    )
+                    for i, log in enumerate(model_object.task_result.logs):
+                        json_log = task_result_json.get("logs")[i]
+                        if "log" in json_log:
+                            assert log.log == json_log.get("log")
+                        if "createdTime" in json_log:
+                            assert log.created_time == json_log.get("createdTime")
+                        if "taskId" in json_log:
+                            assert log.task_id == json_log.get("taskId")
+                # Normal field comparison
                 else:
-                    serialized_json[camel_key] = result_dict[snake_key]
-
-        # Step 5: Verify the resulting JSON matches the original
-        # Check that all keys from original JSON exist in the serialized JSON
-        for key in self.server_json:
-            self.assertIn(key, serialized_json)
-
-            # Skip detailed comparison of TaskResult as it's complex and some fields might be missing
-            # Just check that the main structure is there
-            if key == "taskResult" and self.server_json[key] is not None:
-                for tr_key in self.server_json[key]:
-                    # Skip extendLease if it's false in our model but not present in JSON
-                    if tr_key == "extendLease" and tr_key not in serialized_json[key] and not self.server_json[key][
-                        tr_key]:
-                        continue
-
-                    # Allow missing fields if they're None or empty collections
-                    if tr_key not in serialized_json[key]:
-                        # If it's a complex field that's missing, just note it's acceptable
-                        # For logs, outputData, etc. that can be empty
-                        if isinstance(self.server_json[key][tr_key], (dict, list)) and not self.server_json[key][
-                            tr_key]:
-                            continue
-                        # For primitive fields, if null/None/false, it's acceptable to be missing
-                        if self.server_json[key][tr_key] in (None, False, "", 0):
-                            continue
-
-                        # If it's an important value that's missing, fail the test
-                        self.fail(f"Key {tr_key} missing from serialized TaskResult")
-
-                    # For fields that exist in both, compare values
-                    elif tr_key in serialized_json[key]:
-                        # Special handling for logs and other complex types
-                        if tr_key == "logs" and isinstance(self.server_json[key][tr_key], list):
-                            # Check logs length
-                            self.assertEqual(len(serialized_json[key][tr_key]), len(self.server_json[key][tr_key]))
-
-                            # Check each log entry for key fields, being careful with field mapping
-                            for i, log in enumerate(self.server_json[key][tr_key]):
-                                for log_key in log:
-                                    # Handle the case where the field might be named differently
-                                    # in the serialized output versus the JSON template
-                                    serialized_log = serialized_json[key][tr_key][i]
-
-                                    # Try to find the corresponding field in serialized log
-                                    if log_key in serialized_log:
-                                        self.assertEqual(serialized_log[log_key], log[log_key])
-                                    else:
-                                        # Check if this is a field that has a different name in snake_case
-                                        # Find the snake_case equivalent for the log_key
-                                        snake_case_found = False
-                                        if hasattr(TaskExecLog, "attribute_map"):
-                                            for snake_key, camel_key in TaskExecLog.attribute_map.items():
-                                                if camel_key == log_key:
-                                                    # Found the snake_case key corresponding to this camel_case key
-                                                    if snake_key in serialized_log:
-                                                        self.assertEqual(serialized_log[snake_key], log[log_key])
-                                                        snake_case_found = True
-                                                        break
-
-                                        # Skip error if field is optional or has default value
-                                        if not snake_case_found and log[log_key] in (None, "", 0, False):
-                                            continue
-
-                                        # If the field is important and missing, log it but don't fail
-                                        # This is a common case for automatically generated models
-                                        if not snake_case_found:
-                                            print(
-                                                f"Warning: Field {log_key} not found in serialized log. Original value: {log[log_key]}")
-                        # For scalar values, direct comparison
+                    python_field_value = getattr(model_object.task_result, json_key)
+                    json_field_value = task_result_json.get(python_attr)
+                    assert python_field_value == json_field_value
+    if server_json.get("variables"):
+        assert model_object.variables == server_json.get("variables")
+    # Step 3: Serialize the model back to dict
+    result_dict = model_object.to_dict()
+    # Step 4: Convert result_dict to match the original JSON structure
+    serialized_json = {}
+    # Map snake_case keys to camelCase based on attribute_map
+    for snake_key, camel_key in WorkflowStateUpdate.attribute_map.items():
+        if snake_key in result_dict and result_dict[snake_key] is not None:
+            if snake_key == "task_result" and result_dict[snake_key]:
+                # Handle TaskResult conversion
+                task_result_dict = result_dict[snake_key]
+                serialized_task_result = {}
+                # Map TaskResult fields using its attribute_map
+                for tr_snake_key, tr_camel_key in TaskResult.attribute_map.items():
+                    if (
+                        tr_snake_key in task_result_dict
+                        and task_result_dict[tr_snake_key] is not None
+                    ):
+                        # Special handling for status which could be an enum
+                        if tr_snake_key == "status" and isinstance(
+                            task_result_dict[tr_snake_key], TaskResultStatus
+                        ):
+                            serialized_task_result[tr_camel_key] = task_result_dict[
+                                tr_snake_key
+                            ].name
+                        # Special handling for logs which are objects
+                        elif tr_snake_key == "logs" and task_result_dict[tr_snake_key]:
+                            serialized_logs = []
+                            for log in task_result_dict[tr_snake_key]:
+                                if hasattr(log, "to_dict"):
+                                    log_dict = log.to_dict()
+                                    # Convert log dict keys to camelCase
+                                    serialized_log = {}
+                                    for log_key, log_value in log_dict.items():
+                                        if (
+                                            hasattr(TaskExecLog, "attribute_map")
+                                            and log_key in TaskExecLog.attribute_map
+                                        ):
+                                            serialized_log[
+                                                TaskExecLog.attribute_map[log_key]
+                                            ] = log_value
+                                        else:
+                                            serialized_log[log_key] = log_value
+                                    serialized_logs.append(serialized_log)
+                                else:
+                                    serialized_logs.append(log)
+                            serialized_task_result[tr_camel_key] = serialized_logs
                         else:
-                            self.assertEqual(serialized_json[key][tr_key], self.server_json[key][tr_key])
-            # For other fields, direct comparison
+                            serialized_task_result[tr_camel_key] = task_result_dict[
+                                tr_snake_key
+                            ]
+                serialized_json[camel_key] = serialized_task_result
             else:
-                self.assertEqual(serialized_json[key], self.server_json[key])
-
-
-if __name__ == '__main__':
-    unittest.main()
+                serialized_json[camel_key] = result_dict[snake_key]
+    # Step 5: Verify the resulting JSON matches the original
+    # Check that all keys from original JSON exist in the serialized JSON
+    for key in server_json:
+        assert key in serialized_json
+        # Skip detailed comparison of TaskResult as it's complex and some fields might be missing
+        # Just check that the main structure is there
+        if key == "taskResult" and server_json[key] is not None:
+            for tr_key in server_json[key]:
+                # Skip extendLease if it's false in our model but not present in JSON
+                if (
+                    tr_key == "extendLease"
+                    and tr_key not in serialized_json[key]
+                    and not server_json[key][tr_key]
+                ):
+                    continue
+                # Allow missing fields if they're None or empty collections
+                if tr_key not in serialized_json[key]:
+                    # If it's a complex field that's missing, just note it's acceptable
+                    # For logs, outputData, etc. that can be empty
+                    if (
+                        isinstance(server_json[key][tr_key], (dict, list))
+                        and not server_json[key][tr_key]
+                    ):
+                        continue
+                    # For primitive fields, if null/None/false, it's acceptable to be missing
+                    if server_json[key][tr_key] in (None, False, "", 0):
+                        continue
+                    # If it's an important value that's missing, fail the test
+                    raise Exception(f"Key {tr_key} missing from serialized TaskResult")
+                # For fields that exist in both, compare values
+                elif tr_key in serialized_json[key]:
+                    # Special handling for logs and other complex types
+                    if tr_key == "logs" and isinstance(server_json[key][tr_key], list):
+                        # Check logs length
+                        assert len(serialized_json[key][tr_key]) == len(
+                            server_json[key][tr_key]
+                        )
+                        # Check each log entry for key fields, being careful with field mapping
+                        for i, log in enumerate(server_json[key][tr_key]):
+                            for log_key in log:
+                                # Handle the case where the field might be named differently
+                                # in the serialized output versus the JSON template
+                                serialized_log = serialized_json[key][tr_key][i]
+                                # Try to find the corresponding field in serialized log
+                                if log_key in serialized_log:
+                                    assert serialized_log[log_key] == log[log_key]
+                                else:
+                                    # Check if this is a field that has a different name in snake_case
+                                    # Find the snake_case equivalent for the log_key
+                                    snake_case_found = False
+                                    if hasattr(TaskExecLog, "attribute_map"):
+                                        for (
+                                            snake_key,
+                                            camel_key,
+                                        ) in TaskExecLog.attribute_map.items():
+                                            if camel_key == log_key:
+                                                # Found the snake_case key corresponding to this camel_case key
+                                                if snake_key in serialized_log:
+                                                    assert (
+                                                        serialized_log[snake_key]
+                                                        == log[log_key]
+                                                    )
+                                                    snake_case_found = True
+                                                    break
+                                    # Skip error if field is optional or has default value
+                                    if not snake_case_found and log[log_key] in (
+                                        None,
+                                        "",
+                                        0,
+                                        False,
+                                    ):
+                                        continue
+                                    # If the field is important and missing, log it but don't fail
+                                    # This is a common case for automatically generated models
+                                    if not snake_case_found:
+                                        print(
+                                            f"Warning: Field {log_key} not found in serialized log. Original value: {log[log_key]}"
+                                        )
+                    # For scalar values, direct comparison
+                    else:
+                        assert serialized_json[key][tr_key] == server_json[key][tr_key]
+        # For other fields, direct comparison
+        else:
+            assert serialized_json[key] == server_json[key]

--- a/tests/serdesertest/test_serdeser_workflow_status.py
+++ b/tests/serdesertest/test_serdeser_workflow_status.py
@@ -1,64 +1,55 @@
-import unittest
 import json
-from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
+
+import pytest
+
 from conductor.client.http.models.workflow_status import WorkflowStatus
+from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestWorkflowStatusSerDes(unittest.TestCase):
-    def setUp(self):
-        self.server_json_str = JsonTemplateResolver.get_json_string("WorkflowStatus")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_workflow_status_ser_des(self):
-        # 1. Test deserialization from server JSON to SDK model
-        workflow_status = WorkflowStatus(
-            workflow_id=self.server_json.get("workflowId"),
-            correlation_id=self.server_json.get("correlationId"),
-            output=self.server_json.get("output"),
-            variables=self.server_json.get("variables"),
-            status=self.server_json.get("status")
-        )
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get("workflowId"), workflow_status.workflow_id)
-        self.assertEqual(self.server_json.get("correlationId"), workflow_status.correlation_id)
-        self.assertEqual(self.server_json.get("output"), workflow_status.output)
-        self.assertEqual(self.server_json.get("variables"), workflow_status.variables)
-        self.assertEqual(self.server_json.get("status"), workflow_status.status)
-
-        # Check status-based methods work correctly
-        if workflow_status.status in ['COMPLETED', 'FAILED', 'TIMED_OUT', 'TERMINATED']:
-            self.assertTrue(workflow_status.is_completed())
-        else:
-            self.assertFalse(workflow_status.is_completed())
-
-        if workflow_status.status in ['PAUSED', 'COMPLETED']:
-            self.assertTrue(workflow_status.is_successful())
-        else:
-            self.assertFalse(workflow_status.is_successful())
-
-        if workflow_status.status in ['RUNNING', 'PAUSED']:
-            self.assertTrue(workflow_status.is_running())
-        else:
-            self.assertFalse(workflow_status.is_running())
-
-        # 3. Test serialization back to JSON
-        serialized_json = workflow_status.to_dict()
-
-        # 4. Verify the serialized JSON matches the original JSON
-        self.assertEqual(self.server_json.get("workflowId"), serialized_json.get("workflow_id"))
-        self.assertEqual(self.server_json.get("correlationId"), serialized_json.get("correlation_id"))
-        self.assertEqual(self.server_json.get("output"), serialized_json.get("output"))
-        self.assertEqual(self.server_json.get("variables"), serialized_json.get("variables"))
-        self.assertEqual(self.server_json.get("status"), serialized_json.get("status"))
-
-        # Additional test for special data structures if present in the template
-        if isinstance(self.server_json.get("output"), dict):
-            self.assertEqual(self.server_json.get("output"), workflow_status.output)
-
-        if isinstance(self.server_json.get("variables"), dict):
-            self.assertEqual(self.server_json.get("variables"), workflow_status.variables)
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("WorkflowStatus")
+    return json.loads(server_json_str)
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_workflow_status_ser_des(server_json):
+    # 1. Test deserialization from server JSON to SDK model
+    workflow_status = WorkflowStatus(
+        workflow_id=server_json.get("workflowId"),
+        correlation_id=server_json.get("correlationId"),
+        output=server_json.get("output"),
+        variables=server_json.get("variables"),
+        status=server_json.get("status"),
+    )
+    # 2. Verify all fields are properly populated
+    assert server_json.get("workflowId") == workflow_status.workflow_id
+    assert server_json.get("correlationId") == workflow_status.correlation_id
+    assert server_json.get("output") == workflow_status.output
+    assert server_json.get("variables") == workflow_status.variables
+    assert server_json.get("status") == workflow_status.status
+    # Check status-based methods work correctly
+    if workflow_status.status in ["COMPLETED", "FAILED", "TIMED_OUT", "TERMINATED"]:
+        assert workflow_status.is_completed()
+    else:
+        assert not workflow_status.is_completed()
+    if workflow_status.status in ["PAUSED", "COMPLETED"]:
+        assert workflow_status.is_successful()
+    else:
+        assert not workflow_status.is_successful()
+    if workflow_status.status in ["RUNNING", "PAUSED"]:
+        assert workflow_status.is_running()
+    else:
+        assert not workflow_status.is_running()
+    # 3. Test serialization back to JSON
+    serialized_json = workflow_status.to_dict()
+    # 4. Verify the serialized JSON matches the original JSON
+    assert server_json.get("workflowId") == serialized_json.get("workflow_id")
+    assert server_json.get("correlationId") == serialized_json.get("correlation_id")
+    assert server_json.get("output") == serialized_json.get("output")
+    assert server_json.get("variables") == serialized_json.get("variables")
+    assert server_json.get("status") == serialized_json.get("status")
+    # Additional test for special data structures if present in the template
+    if isinstance(server_json.get("output"), dict):
+        assert server_json.get("output") == workflow_status.output
+    if isinstance(server_json.get("variables"), dict):
+        assert server_json.get("variables") == workflow_status.variables

--- a/tests/serdesertest/test_serdeser_workflow_summary.py
+++ b/tests/serdesertest/test_serdeser_workflow_summary.py
@@ -1,117 +1,115 @@
-import unittest
 import json
-from typing import Set
+
+import pytest
+
 from conductor.client.http.models.workflow_summary import WorkflowSummary
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestWorkflowSummarySerialization(unittest.TestCase):
-    def setUp(self):
-        # Load JSON template using JsonTemplateResolver
-        self.server_json_str = JsonTemplateResolver.get_json_string("WorkflowSummary")
-        self.server_json = json.loads(self.server_json_str)
-
-    def test_workflow_summary_serde(self):
-        # Test deserialization from JSON to SDK model
-        model = WorkflowSummary(
-            workflow_type=self.server_json.get("workflowType"),
-            version=self.server_json.get("version"),
-            workflow_id=self.server_json.get("workflowId"),
-            correlation_id=self.server_json.get("correlationId"),
-            start_time=self.server_json.get("startTime"),
-            update_time=self.server_json.get("updateTime"),
-            end_time=self.server_json.get("endTime"),
-            status=self.server_json.get("status"),
-            input=self.server_json.get("input"),
-            output=self.server_json.get("output"),
-            reason_for_incompletion=self.server_json.get("reasonForIncompletion"),
-            execution_time=self.server_json.get("executionTime"),
-            event=self.server_json.get("event"),
-            failed_reference_task_names=self.server_json.get("failedReferenceTaskNames"),
-            external_input_payload_storage_path=self.server_json.get("externalInputPayloadStoragePath"),
-            external_output_payload_storage_path=self.server_json.get("externalOutputPayloadStoragePath"),
-            priority=self.server_json.get("priority"),
-            created_by=self.server_json.get("createdBy"),
-            output_size=self.server_json.get("outputSize"),
-            input_size=self.server_json.get("inputSize"),
-            failed_task_names=set(self.server_json.get("failedTaskNames", []))
-        )
-
-        # Verify all fields are properly populated
-        self._verify_fields(model)
-
-        # Serialize the model back to a dict
-        serialized_dict = model.to_dict()
-
-        # Transform Python snake_case keys to JSON camelCase
-        json_dict = self._transform_to_json_format(serialized_dict)
-
-        # Verify the serialized JSON matches the original (with expected transformations)
-        self._verify_json_matches(json_dict, self.server_json)
-
-    def _verify_fields(self, model: WorkflowSummary):
-        """Verify all fields in the model are correctly populated."""
-        self.assertEqual(model.workflow_type, self.server_json.get("workflowType"))
-        self.assertEqual(model.version, self.server_json.get("version"))
-        self.assertEqual(model.workflow_id, self.server_json.get("workflowId"))
-        self.assertEqual(model.correlation_id, self.server_json.get("correlationId"))
-        self.assertEqual(model.start_time, self.server_json.get("startTime"))
-        self.assertEqual(model.update_time, self.server_json.get("updateTime"))
-        self.assertEqual(model.end_time, self.server_json.get("endTime"))
-        self.assertEqual(model.status, self.server_json.get("status"))
-        self.assertEqual(model.input, self.server_json.get("input"))
-        self.assertEqual(model.output, self.server_json.get("output"))
-        self.assertEqual(model.reason_for_incompletion, self.server_json.get("reasonForIncompletion"))
-        self.assertEqual(model.execution_time, self.server_json.get("executionTime"))
-        self.assertEqual(model.event, self.server_json.get("event"))
-        self.assertEqual(model.failed_reference_task_names, self.server_json.get("failedReferenceTaskNames"))
-        self.assertEqual(model.external_input_payload_storage_path,
-                         self.server_json.get("externalInputPayloadStoragePath"))
-        self.assertEqual(model.external_output_payload_storage_path,
-                         self.server_json.get("externalOutputPayloadStoragePath"))
-        self.assertEqual(model.priority, self.server_json.get("priority"))
-        self.assertEqual(model.created_by, self.server_json.get("createdBy"))
-
-        # Special handling for Set type
-        if "failedTaskNames" in self.server_json:
-            self.assertIsInstance(model.failed_task_names, set)
-            self.assertEqual(model.failed_task_names, set(self.server_json.get("failedTaskNames")))
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("WorkflowSummary")
+    return json.loads(server_json_str)
 
 
-    def _transform_to_json_format(self, python_dict):
-        """Transform Python dict keys from snake_case to camelCase for JSON comparison."""
-        attribute_map = WorkflowSummary.attribute_map
-        result = {}
+def test_workflow_summary_serde(server_json):
+    # Test deserialization from JSON to SDK model
+    model = WorkflowSummary(
+        workflow_type=server_json.get("workflowType"),
+        version=server_json.get("version"),
+        workflow_id=server_json.get("workflowId"),
+        correlation_id=server_json.get("correlationId"),
+        start_time=server_json.get("startTime"),
+        update_time=server_json.get("updateTime"),
+        end_time=server_json.get("endTime"),
+        status=server_json.get("status"),
+        input=server_json.get("input"),
+        output=server_json.get("output"),
+        reason_for_incompletion=server_json.get("reasonForIncompletion"),
+        execution_time=server_json.get("executionTime"),
+        event=server_json.get("event"),
+        failed_reference_task_names=server_json.get("failedReferenceTaskNames"),
+        external_input_payload_storage_path=server_json.get(
+            "externalInputPayloadStoragePath"
+        ),
+        external_output_payload_storage_path=server_json.get(
+            "externalOutputPayloadStoragePath"
+        ),
+        priority=server_json.get("priority"),
+        created_by=server_json.get("createdBy"),
+        output_size=server_json.get("outputSize"),
+        input_size=server_json.get("inputSize"),
+        failed_task_names=set(server_json.get("failedTaskNames", [])),
+    )
+    _verify_fields(model, server_json)
+    # Serialize the model back to a dict
+    serialized_dict = model.to_dict()
+    # Transform Python snake_case keys to JSON camelCase
+    json_dict = _transform_to_json_format(serialized_dict)
+    # Verify the serialized JSON matches the original (with expected transformations)
+    _verify_json_matches(json_dict, server_json)
 
-        for py_key, value in python_dict.items():
-            # Get the corresponding JSON key from attribute_map
-            if py_key in attribute_map:
-                json_key = attribute_map[py_key]
 
-                # Handle special types (lists, dicts, etc.)
-                if isinstance(value, set):
-                    result[json_key] = list(value)
-                elif isinstance(value, dict):
-                    # Handle nested dictionaries if needed
-                    result[json_key] = value
-                else:
-                    result[json_key] = value
+def _verify_fields(model: WorkflowSummary, server_json):
+    """Verify all fields in the model are correctly populated."""
+    assert model.workflow_type == server_json.get("workflowType")
+    assert model.version == server_json.get("version")
+    assert model.workflow_id == server_json.get("workflowId")
+    assert model.correlation_id == server_json.get("correlationId")
+    assert model.start_time == server_json.get("startTime")
+    assert model.update_time == server_json.get("updateTime")
+    assert model.end_time == server_json.get("endTime")
+    assert model.status == server_json.get("status")
+    assert model.input == server_json.get("input")
+    assert model.output == server_json.get("output")
+    assert model.reason_for_incompletion == server_json.get("reasonForIncompletion")
+    assert model.execution_time == server_json.get("executionTime")
+    assert model.event == server_json.get("event")
+    assert model.failed_reference_task_names == server_json.get(
+        "failedReferenceTaskNames"
+    )
+    assert model.external_input_payload_storage_path == server_json.get(
+        "externalInputPayloadStoragePath"
+    )
+    assert model.external_output_payload_storage_path == server_json.get(
+        "externalOutputPayloadStoragePath"
+    )
+    assert model.priority == server_json.get("priority")
+    assert model.created_by == server_json.get("createdBy")
+    # Special handling for Set type
+    if "failedTaskNames" in server_json:
+        assert isinstance(model.failed_task_names, set)
+        assert model.failed_task_names == set(server_json.get("failedTaskNames"))
 
-        return result
 
-    def _verify_json_matches(self, transformed_dict, original_json):
-        """Verify that the serialized and transformed dict matches the original JSON."""
-        # Check that all fields in the original JSON are present in the transformed dict
-        for key in original_json:
-            # Handle special case for failedTaskNames (set in Python, list in JSON)
-            if key == "failedTaskNames":
-                self.assertIn(key, transformed_dict)
-                self.assertIsInstance(transformed_dict[key], list)
-                self.assertEqual(set(transformed_dict[key]), set(original_json[key]))
+def _transform_to_json_format(python_dict):
+    """Transform Python dict keys from snake_case to camelCase for JSON comparison."""
+    attribute_map = WorkflowSummary.attribute_map
+    result = {}
+    for py_key, value in python_dict.items():
+        # Get the corresponding JSON key from attribute_map
+        if py_key in attribute_map:
+            json_key = attribute_map[py_key]
+            # Handle special types (lists, dicts, etc.)
+            if isinstance(value, set):
+                result[json_key] = list(value)
+            elif isinstance(value, dict):
+                # Handle nested dictionaries if needed
+                result[json_key] = value
             else:
-                self.assertIn(key, transformed_dict)
-                self.assertEqual(transformed_dict[key], original_json[key])
+                result[json_key] = value
+    return result
 
 
-if __name__ == '__main__':
-    unittest.main()
+def _verify_json_matches(transformed_dict, original_json):
+    """Verify that the serialized and transformed dict matches the original JSON."""
+    # Check that all fields in the original JSON are present in the transformed dict
+    for key in original_json:
+        # Handle special case for failedTaskNames (set in Python, list in JSON)
+        if key == "failedTaskNames":
+            assert key in transformed_dict
+            assert isinstance(transformed_dict[key], list)
+            assert set(transformed_dict[key]) == set(original_json[key])
+        else:
+            assert key in transformed_dict
+            assert transformed_dict[key] == original_json[key]

--- a/tests/serdesertest/test_serdeser_workflow_task.py
+++ b/tests/serdesertest/test_serdeser_workflow_task.py
@@ -1,120 +1,72 @@
-import unittest
 import json
+
 from conductor.client.http.models.workflow_task import WorkflowTask
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestWorkflowTaskSerDe(unittest.TestCase):
-    def test_workflow_task_serde(self):
-        # 1. Load the JSON template
-        server_json_str = JsonTemplateResolver.get_json_string("WorkflowTask")
-        server_json = json.loads(server_json_str)
+def to_camel_case(snake_str):
+    components = snake_str.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
 
-        # Function to convert snake_case to camelCase
-        def to_camel_case(snake_str):
-            components = snake_str.split('_')
-            return components[0] + ''.join(x.title() for x in components[1:])
 
-        # Map the JSON fields to Python attributes
-        mapped_kwargs = {}
-        for json_key, value in server_json.items():
-            # Find the corresponding Python attribute name
-            for py_attr, mapped_json in WorkflowTask.attribute_map.items():
-                if mapped_json == json_key:
-                    mapped_kwargs[py_attr] = value
+def workflow_task_to_json_dict(task):
+    result = {}
+    for snake_attr in task.swagger_types:
+        value = getattr(task, snake_attr)
+        if value is not None:
+            if snake_attr in task.attribute_map:
+                json_attr = task.attribute_map[snake_attr]
+            else:
+                json_attr = to_camel_case(snake_attr)
+            if isinstance(value, list):
+                result[json_attr] = [
+                    item.to_dict() if hasattr(item, "to_dict") else item
+                    for item in value
+                ]
+            elif hasattr(value, "to_dict"):
+                result[json_attr] = value.to_dict()
+            elif isinstance(value, dict):
+                result[json_attr] = {
+                    k: v.to_dict() if hasattr(v, "to_dict") else v
+                    for k, v in value.items()
+                }
+            else:
+                result[json_attr] = value
+    return result
+
+
+def test_workflow_task_serde():
+    server_json_str = JsonTemplateResolver.get_json_string("WorkflowTask")
+    server_json = json.loads(server_json_str)
+    mapped_kwargs = {}
+    for json_key, value in server_json.items():
+        for py_attr, mapped_json in WorkflowTask.attribute_map.items():
+            if mapped_json == json_key:
+                mapped_kwargs[py_attr] = value
+                break
+    workflow_task = WorkflowTask(**mapped_kwargs)
+    assert server_json.get("name") == workflow_task.name
+    assert server_json.get("taskReferenceName") == workflow_task.task_reference_name
+    if "joinOn" in server_json:
+        assert server_json.get("joinOn") == workflow_task.join_on
+    result_dict = workflow_task.to_dict()
+    converted_dict = {}
+    for key, value in result_dict.items():
+        if value is not None:
+            camel_key = key
+            for py_attr, json_attr in WorkflowTask.attribute_map.items():
+                if py_attr == key:
+                    camel_key = json_attr
                     break
-
-        # Create the workflow task with the properly mapped fields
-        workflow_task = WorkflowTask(**mapped_kwargs)
-
-        # Verify key fields were deserialized correctly
-        self.assertEqual(server_json.get("name"), workflow_task.name)
-        self.assertEqual(server_json.get("taskReferenceName"), workflow_task.task_reference_name)
-
-        if "joinOn" in server_json:
-            self.assertEqual(server_json.get("joinOn"), workflow_task.join_on)
-
-        # Get the serialized dict
-        result_dict = workflow_task.to_dict()
-
-        # The issue: to_dict() returns snake_case keys instead of camelCase
-        # We need to convert the keys back to camelCase
-        converted_dict = {}
-        for key, value in result_dict.items():
-            # Skip None values to match Java behavior
-            if value is not None:
-                # Use attribute_map if possible
-                camel_key = key
-                for py_attr, json_attr in WorkflowTask.attribute_map.items():
-                    if py_attr == key:
-                        camel_key = json_attr
-                        break
-                converted_dict[camel_key] = value
-
-        # Now write a proper test that passes
-        # Create a fixed function to properly serialize WorkflowTask to JSON
-        def workflow_task_to_json_dict(task):
-            """Correctly convert WorkflowTask to JSON dict with camelCase keys"""
-            result = {}
-            # Go through all attributes defined in swagger_types
-            for snake_attr in task.swagger_types:
-                # Get the value from the object
-                value = getattr(task, snake_attr)
-                # Skip None values
-                if value is not None:
-                    # Find the JSON field name from attribute_map
-                    if snake_attr in task.attribute_map:
-                        json_attr = task.attribute_map[snake_attr]
-                    else:
-                        # If not in attribute_map, convert manually
-                        json_attr = to_camel_case(snake_attr)
-
-                    # Handle complex types (nested objects, lists, dicts)
-                    if isinstance(value, list):
-                        # Convert each item in the list
-                        result[json_attr] = [
-                            item.to_dict() if hasattr(item, "to_dict") else item
-                            for item in value
-                        ]
-                    elif hasattr(value, "to_dict"):
-                        # Nested object
-                        result[json_attr] = value.to_dict()
-                    elif isinstance(value, dict):
-                        # Handle dictionaries
-                        result[json_attr] = {
-                            k: v.to_dict() if hasattr(v, "to_dict") else v
-                            for k, v in value.items()
-                        }
-                    else:
-                        # Simple value
-                        result[json_attr] = value
-            return result
-
-        # Use our fixed function to generate a proper JSON dict
-        fixed_json_dict = workflow_task_to_json_dict(workflow_task)
-
-        # Now verify that key fields are present with camelCase keys
-        self.assertIn("name", fixed_json_dict)
-        self.assertIn("taskReferenceName", fixed_json_dict)
-
-        if workflow_task.join_on is not None:
-            self.assertIn("joinOn", fixed_json_dict)
-            self.assertEqual(workflow_task.join_on, fixed_json_dict["joinOn"])
-
-        # Print summary of fields in fixed JSON dict
-        # print("Fields in fixed JSON dict:", fixed_json_dict.keys())
-
-        # Demonstrate this approach works for a simple test case
-        test_task = WorkflowTask(
-            name="Test Task",
-            task_reference_name="testRef"
-        )
-        test_task.join_on = ["task1", "task2"]
-
-        fixed_test_dict = workflow_task_to_json_dict(test_task)
-        self.assertIn("joinOn", fixed_test_dict)
-        self.assertEqual(test_task.join_on, fixed_test_dict["joinOn"])
-
-
-if __name__ == '__main__':
-    unittest.main()
+            converted_dict[camel_key] = value
+    fixed_json_dict = workflow_task_to_json_dict(workflow_task)
+    assert "name" in fixed_json_dict
+    assert "taskReferenceName" in fixed_json_dict
+    if workflow_task.join_on is not None:
+        assert "joinOn" in fixed_json_dict
+        assert workflow_task.join_on == fixed_json_dict["joinOn"]
+    test_task = WorkflowTask(name="Test Task", task_reference_name="testRef")
+    test_task.join_on = ["task1", "task2"]
+    fixed_test_dict = workflow_task_to_json_dict(test_task)
+    assert "joinOn" in fixed_test_dict
+    assert test_task.join_on == fixed_test_dict["joinOn"]

--- a/tests/serdesertest/test_serdeser_workflow_test_request.py
+++ b/tests/serdesertest/test_serdeser_workflow_test_request.py
@@ -1,172 +1,155 @@
-import unittest
 import json
-from conductor.client.http.models.workflow_test_request import WorkflowTestRequest, TaskMock
+
+import pytest
+
 from conductor.client.http.models.workflow_def import WorkflowDef
+from conductor.client.http.models.workflow_test_request import (
+    TaskMock,
+    WorkflowTestRequest,
+)
 from tests.serdesertest.util.serdeser_json_resolver_utility import JsonTemplateResolver
 
 
-class TestWorkflowTestRequestSerDes(unittest.TestCase):
-    """Unit test for WorkflowTestRequest serialization and deserialization"""
+@pytest.fixture
+def server_json():
+    server_json_str = JsonTemplateResolver.get_json_string("WorkflowTestRequest")
+    return json.loads(server_json_str)
 
-    def setUp(self):
-        # Load JSON template from JsonTemplateResolver
-        self.server_json_str = JsonTemplateResolver.get_json_string("WorkflowTestRequest")
-        self.server_json = json.loads(self.server_json_str)
 
-    def snake_to_camel(self, snake_case):
-        """Convert snake_case to camelCase"""
-        components = snake_case.split('_')
-        return components[0] + ''.join(x.title() for x in components[1:])
+def snake_to_camel(snake_case):
+    """Convert snake_case to camelCase"""
+    components = snake_case.split("_")
+    return components[0] + "".join(x.title() for x in components[1:])
 
-    def test_workflow_test_request_serdes(self):
-        """Test serialization and deserialization of WorkflowTestRequest"""
 
-        # 1. Deserialize JSON into SDK model object
-        workflow_test_request = WorkflowTestRequest(
-            correlation_id=self.server_json.get("correlationId"),
-            created_by=self.server_json.get("createdBy"),
-            external_input_payload_storage_path=self.server_json.get("externalInputPayloadStoragePath"),
-            input=self.server_json.get("input"),
-            name=self.server_json.get("name"),
-            priority=self.server_json.get("priority"),
-            version=self.server_json.get("version")
-        )
-
-        # Handle complex nested structures
-        if "taskToDomain" in self.server_json:
-            workflow_test_request.task_to_domain = self.server_json.get("taskToDomain")
-
-        # Handle workflowDef object if present
-        if "workflowDef" in self.server_json and self.server_json["workflowDef"] is not None:
-            workflow_def = WorkflowDef()
-            # Assuming there are fields in WorkflowDef that need to be populated
-            workflow_test_request.workflow_def = workflow_def
-
-        # Handle subWorkflowTestRequest if present
-        if "subWorkflowTestRequest" in self.server_json and self.server_json["subWorkflowTestRequest"]:
-            sub_workflow_dict = {}
-            for key, value in self.server_json["subWorkflowTestRequest"].items():
-                # Create a sub-request for each entry
-                sub_request = WorkflowTestRequest(name=value.get("name"))
-                sub_workflow_dict[key] = sub_request
-            workflow_test_request.sub_workflow_test_request = sub_workflow_dict
-
-        # Handle taskRefToMockOutput if present
-        if "taskRefToMockOutput" in self.server_json and self.server_json["taskRefToMockOutput"]:
-            task_mock_dict = {}
-            for task_ref, mock_list in self.server_json["taskRefToMockOutput"].items():
-                task_mocks = []
-                for mock_data in mock_list:
-                    task_mock = TaskMock(
-                        status=mock_data.get("status", "COMPLETED"),
-                        output=mock_data.get("output"),
-                        execution_time=mock_data.get("executionTime", 0),
-                        queue_wait_time=mock_data.get("queueWaitTime", 0)
-                    )
-                    task_mocks.append(task_mock)
-                task_mock_dict[task_ref] = task_mocks
-            workflow_test_request.task_ref_to_mock_output = task_mock_dict
-
-        # 2. Verify all fields are properly populated
-        self.assertEqual(self.server_json.get("correlationId"), workflow_test_request.correlation_id)
-        self.assertEqual(self.server_json.get("createdBy"), workflow_test_request.created_by)
-        self.assertEqual(self.server_json.get("name"), workflow_test_request.name)
-        self.assertEqual(self.server_json.get("priority"), workflow_test_request.priority)
-        self.assertEqual(self.server_json.get("version"), workflow_test_request.version)
-
-        # Verify complex nested structures if present
-        if "taskToDomain" in self.server_json:
-            self.assertEqual(self.server_json.get("taskToDomain"), workflow_test_request.task_to_domain)
-
-        if "subWorkflowTestRequest" in self.server_json and self.server_json["subWorkflowTestRequest"]:
-            self.assertIsNotNone(workflow_test_request.sub_workflow_test_request)
-            for key in self.server_json["subWorkflowTestRequest"]:
-                self.assertIn(key, workflow_test_request.sub_workflow_test_request)
-                self.assertEqual(
-                    self.server_json["subWorkflowTestRequest"][key].get("name"),
-                    workflow_test_request.sub_workflow_test_request[key].name
+def test_workflow_test_request_serdes(server_json):  # noqa: PLR0915
+    """Test serialization and deserialization of WorkflowTestRequest"""
+    # 1. Deserialize JSON into SDK model object
+    workflow_test_request = WorkflowTestRequest(
+        correlation_id=server_json.get("correlationId"),
+        created_by=server_json.get("createdBy"),
+        external_input_payload_storage_path=server_json.get(
+            "externalInputPayloadStoragePath"
+        ),
+        input=server_json.get("input"),
+        name=server_json.get("name"),
+        priority=server_json.get("priority"),
+        version=server_json.get("version"),
+    )
+    # Handle complex nested structures
+    if "taskToDomain" in server_json:
+        workflow_test_request.task_to_domain = server_json.get("taskToDomain")
+    # Handle workflowDef object if present
+    if "workflowDef" in server_json and server_json["workflowDef"] is not None:
+        workflow_def = WorkflowDef()
+        # Assuming there are fields in WorkflowDef that need to be populated
+        workflow_test_request.workflow_def = workflow_def
+    # Handle subWorkflowTestRequest if present
+    if server_json.get("subWorkflowTestRequest"):
+        sub_workflow_dict = {}
+        for key, value in server_json["subWorkflowTestRequest"].items():
+            # Create a sub-request for each entry
+            sub_request = WorkflowTestRequest(name=value.get("name"))
+            sub_workflow_dict[key] = sub_request
+        workflow_test_request.sub_workflow_test_request = sub_workflow_dict
+    # Handle taskRefToMockOutput if present
+    if server_json.get("taskRefToMockOutput"):
+        task_mock_dict = {}
+        for task_ref, mock_list in server_json["taskRefToMockOutput"].items():
+            task_mocks = []
+            for mock_data in mock_list:
+                task_mock = TaskMock(
+                    status=mock_data.get("status", "COMPLETED"),
+                    output=mock_data.get("output"),
+                    execution_time=mock_data.get("executionTime", 0),
+                    queue_wait_time=mock_data.get("queueWaitTime", 0),
                 )
+                task_mocks.append(task_mock)
+            task_mock_dict[task_ref] = task_mocks
+        workflow_test_request.task_ref_to_mock_output = task_mock_dict
+    # 2. Verify all fields are properly populated
+    assert server_json.get("correlationId") == workflow_test_request.correlation_id
 
-        if "taskRefToMockOutput" in self.server_json and self.server_json["taskRefToMockOutput"]:
-            self.assertIsNotNone(workflow_test_request.task_ref_to_mock_output)
-            for task_ref in self.server_json["taskRefToMockOutput"]:
-                self.assertIn(task_ref, workflow_test_request.task_ref_to_mock_output)
-                for i, mock_data in enumerate(self.server_json["taskRefToMockOutput"][task_ref]):
-                    self.assertEqual(
-                        mock_data.get("status", "COMPLETED"),
-                        workflow_test_request.task_ref_to_mock_output[task_ref][i].status
-                    )
-                    self.assertEqual(
-                        mock_data.get("output"),
-                        workflow_test_request.task_ref_to_mock_output[task_ref][i].output
-                    )
-
-        # 3. Serialize model back to JSON
-        model_dict = workflow_test_request.to_dict()
-
-        # Convert snake_case keys to camelCase for comparison with original JSON
-        serialized_json = {}
-        for key, value in model_dict.items():
-            camel_key = self.snake_to_camel(key)
-            serialized_json[camel_key] = value
-
-        # 4. Verify the serialized JSON matches the original
-        # Check basic fields match (allowing for null/None differences)
-        if "correlationId" in self.server_json:
-            self.assertEqual(self.server_json["correlationId"], serialized_json["correlationId"])
-        if "createdBy" in self.server_json:
-            self.assertEqual(self.server_json["createdBy"], serialized_json["createdBy"])
-        if "name" in self.server_json:
-            self.assertEqual(self.server_json["name"], serialized_json["name"])
-        if "priority" in self.server_json:
-            self.assertEqual(self.server_json["priority"], serialized_json["priority"])
-        if "version" in self.server_json:
-            self.assertEqual(self.server_json["version"], serialized_json["version"])
-
-        # Check maps and complex structures
-        if "taskToDomain" in self.server_json:
-            self.assertEqual(self.server_json["taskToDomain"], serialized_json["taskToDomain"])
-
-        # Verify that sub-workflow structure is preserved correctly
-        if "subWorkflowTestRequest" in self.server_json and self.server_json["subWorkflowTestRequest"]:
-            self.assertIn("subWorkflowTestRequest", serialized_json)
-            for key in self.server_json["subWorkflowTestRequest"]:
-                self.assertIn(key, serialized_json["subWorkflowTestRequest"])
-                orig_name = self.server_json["subWorkflowTestRequest"][key].get("name")
-                serial_obj = serialized_json["subWorkflowTestRequest"][key]
-
+    assert server_json.get("createdBy") == workflow_test_request.created_by
+    assert server_json.get("name") == workflow_test_request.name
+    assert server_json.get("priority") == workflow_test_request.priority
+    assert server_json.get("version") == workflow_test_request.version
+    # Verify complex nested structures if present
+    if "taskToDomain" in server_json:
+        assert server_json.get("taskToDomain") == workflow_test_request.task_to_domain
+    if server_json.get("subWorkflowTestRequest"):
+        assert workflow_test_request.sub_workflow_test_request is not None
+        for key in server_json["subWorkflowTestRequest"]:
+            assert key in workflow_test_request.sub_workflow_test_request
+            assert (
+                server_json["subWorkflowTestRequest"][key].get("name")
+                == workflow_test_request.sub_workflow_test_request[key].name
+            )
+    if server_json.get("taskRefToMockOutput"):
+        assert workflow_test_request.task_ref_to_mock_output is not None
+        for task_ref in server_json["taskRefToMockOutput"]:
+            assert task_ref in workflow_test_request.task_ref_to_mock_output
+            for i, mock_data in enumerate(server_json["taskRefToMockOutput"][task_ref]):
+                assert (
+                    mock_data.get("status", "COMPLETED")
+                    == workflow_test_request.task_ref_to_mock_output[task_ref][i].status
+                )
+                assert (
+                    mock_data.get("output")
+                    == workflow_test_request.task_ref_to_mock_output[task_ref][i].output
+                )
+    # 3. Serialize model back to JSON
+    model_dict = workflow_test_request.to_dict()
+    # Convert snake_case keys to camelCase for comparison with original JSON
+    serialized_json = {}
+    for key, value in model_dict.items():
+        camel_key = snake_to_camel(key)
+        serialized_json[camel_key] = value
+    # 4. Verify the serialized JSON matches the original
+    # Check basic fields match (allowing for null/None differences)
+    if "correlationId" in server_json:
+        assert server_json["correlationId"] == serialized_json["correlationId"]
+    if "createdBy" in server_json:
+        assert server_json["createdBy"] == serialized_json["createdBy"]
+    if "name" in server_json:
+        assert server_json["name"] == serialized_json["name"]
+    if "priority" in server_json:
+        assert server_json["priority"] == serialized_json["priority"]
+    if "version" in server_json:
+        assert server_json["version"] == serialized_json["version"]
+    # Check maps and complex structures
+    if "taskToDomain" in server_json:
+        assert server_json["taskToDomain"] == serialized_json["taskToDomain"]
+    # Verify that sub-workflow structure is preserved correctly
+    if server_json.get("subWorkflowTestRequest"):
+        assert "subWorkflowTestRequest" in serialized_json
+        for key in server_json["subWorkflowTestRequest"]:
+            assert key in serialized_json["subWorkflowTestRequest"]
+            orig_name = server_json["subWorkflowTestRequest"][key].get("name")
+            serial_obj = serialized_json["subWorkflowTestRequest"][key]
+            # Handle the case where to_dict() might return a dictionary or an object
+            if isinstance(serial_obj, dict):
+                serial_name = serial_obj.get("name")
+            else:
+                # Assuming it's an object with attribute access
+                serial_name = getattr(serial_obj, "name", None)
+            assert orig_name == serial_name
+    # Verify task mock outputs
+    if server_json.get("taskRefToMockOutput"):
+        assert "taskRefToMockOutput" in serialized_json
+        for task_ref in server_json["taskRefToMockOutput"]:
+            assert task_ref in serialized_json["taskRefToMockOutput"]
+            for i, mock_data in enumerate(server_json["taskRefToMockOutput"][task_ref]):
+                orig_status = mock_data.get("status", "COMPLETED")
+                orig_output = mock_data.get("output")
+                serial_mock = serialized_json["taskRefToMockOutput"][task_ref][i]
                 # Handle the case where to_dict() might return a dictionary or an object
-                if isinstance(serial_obj, dict):
-                    serial_name = serial_obj.get("name")
+                if isinstance(serial_mock, dict):
+                    serial_status = serial_mock.get("status")
+                    serial_output = serial_mock.get("output")
                 else:
                     # Assuming it's an object with attribute access
-                    serial_name = getattr(serial_obj, "name", None)
-
-                self.assertEqual(orig_name, serial_name)
-
-        # Verify task mock outputs
-        if "taskRefToMockOutput" in self.server_json and self.server_json["taskRefToMockOutput"]:
-            self.assertIn("taskRefToMockOutput", serialized_json)
-            for task_ref in self.server_json["taskRefToMockOutput"]:
-                self.assertIn(task_ref, serialized_json["taskRefToMockOutput"])
-                for i, mock_data in enumerate(self.server_json["taskRefToMockOutput"][task_ref]):
-                    orig_status = mock_data.get("status", "COMPLETED")
-                    orig_output = mock_data.get("output")
-
-                    serial_mock = serialized_json["taskRefToMockOutput"][task_ref][i]
-
-                    # Handle the case where to_dict() might return a dictionary or an object
-                    if isinstance(serial_mock, dict):
-                        serial_status = serial_mock.get("status")
-                        serial_output = serial_mock.get("output")
-                    else:
-                        # Assuming it's an object with attribute access
-                        serial_status = getattr(serial_mock, "status", None)
-                        serial_output = getattr(serial_mock, "output", None)
-
-                    self.assertEqual(orig_status, serial_status)
-                    self.assertEqual(orig_output, serial_output)
-
-
-if __name__ == "__main__":
-    unittest.main()
+                    serial_status = getattr(serial_mock, "status", None)
+                    serial_output = getattr(serial_mock, "output", None)
+                assert orig_status == serial_status
+                assert orig_output == serial_output

--- a/tests/serdesertest/util/serdeser_json_resolver_utility.py
+++ b/tests/serdesertest/util/serdeser_json_resolver_utility.py
@@ -1,6 +1,5 @@
-import json
-import os
 import copy
+import json
 from pathlib import Path
 
 
@@ -18,9 +17,11 @@ class JsonTemplateResolver:
         file_path = current_dir / cls._template_resource_path
 
         if not file_path.exists():
-            raise FileNotFoundError(f"Resource not found: {cls._template_resource_path}")
+            raise FileNotFoundError(
+                f"Resource not found: {cls._template_resource_path}"
+            )
 
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             root = json.load(f)
 
         if "templates" not in root:
@@ -75,7 +76,9 @@ class JsonTemplateResolver:
         template = cls._templates_root[template_name]
 
         if "content" not in template:
-            raise ValueError(f"Template '{template_name}' does not contain 'content' node")
+            raise ValueError(
+                f"Template '{template_name}' does not contain 'content' node"
+            )
 
         content_node = template["content"]
 
@@ -90,7 +93,9 @@ class JsonTemplateResolver:
         if "inherits" in template and isinstance(template["inherits"], list):
             for parent_name in template["inherits"]:
                 # Resolve parent template
-                parent_node = cls._resolve_template_with_inheritance(parent_name, set(processed_templates))
+                parent_node = cls._resolve_template_with_inheritance(
+                    parent_name, set(processed_templates)
+                )
 
                 # Only merge if parent is a dict
                 if isinstance(parent_node, dict):
@@ -108,7 +113,11 @@ class JsonTemplateResolver:
             for field_name, source_value in source.items():
                 # Only add the field if it doesn't exist in the target
                 if field_name not in target:
-                    if isinstance(source_value, dict) and field_name in target and isinstance(target[field_name], dict):
+                    if (
+                        isinstance(source_value, dict)
+                        and field_name in target
+                        and isinstance(target[field_name], dict)
+                    ):
                         # Recursively merge objects
                         cls._merge_nodes(target[field_name], source_value)
                     else:
@@ -129,7 +138,7 @@ class JsonTemplateResolver:
         # Collect field names to avoid RuntimeError during iteration
         fields_to_process = list(obj_node.keys())
 
-        for field_name in fields_to_process:
+        for i, field_name in enumerate(fields_to_process):
             field_value = obj_node[field_name]
 
             # Check if the field name is a reference that needs to be resolved
@@ -147,7 +156,9 @@ class JsonTemplateResolver:
                 field_dependencies.add(reference_name)
 
                 # Resolve the template to get the actual key name
-                resolved_reference = cls._resolve_template_with_inheritance(reference_name, set())
+                resolved_reference = cls._resolve_template_with_inheritance(
+                    reference_name, set()
+                )
 
                 # Only apply if the resolved reference is a simple value (string, number, etc.)
                 if not isinstance(resolved_reference, (dict, list)):
@@ -158,7 +169,7 @@ class JsonTemplateResolver:
                     obj_node[resolved_key] = original_value
 
                     # Update the field name for further processing
-                    field_name = resolved_key
+                    fields_to_process[i] = resolved_key
                     field_value = original_value
 
             # Check if the field value is a string reference
@@ -172,13 +183,17 @@ class JsonTemplateResolver:
 
                     if reference_name in field_dependencies:
                         # Circular reference detected
-                        print(f"Warning: Circular reference detected for {reference_name}")
+                        print(
+                            f"Warning: Circular reference detected for {reference_name}"
+                        )
                         continue
 
                     field_dependencies.add(reference_name)
 
                     # Resolve the template WITH inheritance
-                    resolved_reference = cls._resolve_template_with_inheritance(reference_name, set())
+                    resolved_reference = cls._resolve_template_with_inheritance(
+                        reference_name, set()
+                    )
 
                     # Resolve any references in the resolved template
                     cls._resolve_references(resolved_reference, field_dependencies)
@@ -203,13 +218,17 @@ class JsonTemplateResolver:
 
                     if reference_name in element_dependencies:
                         # Circular reference detected
-                        print(f"Warning: Circular reference detected for {reference_name}")
+                        print(
+                            f"Warning: Circular reference detected for {reference_name}"
+                        )
                         continue
 
                     element_dependencies.add(reference_name)
 
                     # Resolve the template WITH inheritance
-                    resolved_reference = cls._resolve_template_with_inheritance(reference_name, set())
+                    resolved_reference = cls._resolve_template_with_inheritance(
+                        reference_name, set()
+                    )
 
                     # Resolve any references in the resolved template
                     cls._resolve_references(resolved_reference, element_dependencies)


### PR DESCRIPTION
Changes:

Rewrote tests in the tests/serdesertest package to use pytest

Fixed ruff errors in the tests/serdesertest package

Reason:
Migrating from unittest to pytest for better readability, more concise test syntax and pytest powerful features.