### PR TITLE
Added sync and async integration tests to fail condition

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -81,7 +81,7 @@ jobs:
             /bin/sh -c "cd /package && COVERAGE_FILE=/package/${{ env.COVERAGE_DIR }}/.coverage.integration coverage run -m pytest -m v4 tests/integration -v"
 
       - name: Run asyncio integration tests
-        id: integration_tests
+        id: asyncio_integration_tests
         continue-on-error: true
         run: |
           docker run --rm \
@@ -90,7 +90,7 @@ jobs:
             -e CONDUCTOR_SERVER_URL=${{ env.CONDUCTOR_SERVER_URL }} \
             -v ${{ github.workspace }}/${{ env.COVERAGE_DIR }}:/package/${{ env.COVERAGE_DIR }}:rw \
             conductor-sdk-test:latest \
-            /bin/sh -c "cd /package && COVERAGE_FILE=/package/${{ env.COVERAGE_DIR }}/.coverage.integration coverage run -m pytest -m v4 tests/integration -v"
+            /bin/sh -c "cd /package && COVERAGE_FILE=/package/${{ env.COVERAGE_DIR }}/.coverage.asyncio_integration coverage run -m pytest -m v4 tests/integration/async -v"
 
       - name: Generate coverage report
         id: coverage_report

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -123,5 +123,5 @@ jobs:
           file: ${{ env.COVERAGE_FILE }}
 
       - name: Check test results
-        if: steps.unit_tests.outcome == 'failure' || steps.bc_tests.outcome == 'failure' || steps.serdeser_tests.outcome == 'failure'
+        if: steps.unit_tests.outcome == 'failure' || steps.bc_tests.outcome == 'failure' || steps.serdeser_tests.outcome == 'failure' || steps.integration_tests.outcome == 'failure' || steps.asyncio_integration_tests.outcome == 'failure'
         run: exit 1

--- a/poetry.lock
+++ b/poetry.lock
@@ -704,6 +704,34 @@ files = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+description = "Pure-Python HTTP/2 protocol implementation"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd"},
+    {file = "h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1"},
+]
+
+[package.dependencies]
+hpack = ">=4.1,<5"
+hyperframe = ">=6.1,<7"
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+description = "Pure-Python HPACK header encoding"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496"},
+    {file = "hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca"},
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 description = "A minimal low-level HTTP client."
@@ -740,6 +768,7 @@ files = [
 [package.dependencies]
 anyio = "*"
 certifi = "*"
+h2 = {version = ">=3,<5", optional = true, markers = "extra == \"http2\""}
 httpcore = "==1.*"
 idna = "*"
 
@@ -749,6 +778,18 @@ cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+description = "Pure-Python HTTP/2 framing"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5"},
+    {file = "hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08"},
+]
 
 [[package]]
 name = "identify"
@@ -1923,4 +1964,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "411e7974ef54ceafa183f231175bd4c8df9d4a1f6d2b274731017c614a5f9bca"
+content-hash = "2d36acfc3e5cbafdea8125054c76dac80fd1c4a9fb78b2a72fb2ca942ad60c92"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ python-dateutil = "^2.8.2"
 pydantic = "2.11.7"
 aiohttp = "3.12.15"
 aiohttp-retry = "2.9.1"
-httpx = "^0.28.1"
+httpx = {extras = ["http2"], version = "^0.28.1"}
 
 [tool.poetry.group.dev.dependencies]
 pylint = ">=2.17.5"

--- a/src/conductor/asyncio_client/adapters/models/integration_adapter.py
+++ b/src/conductor/asyncio_client/adapters/models/integration_adapter.py
@@ -29,10 +29,11 @@ class IntegrationAdapter(Integration):
                 "GIT",
                 "EMAIL",
                 "MCP",
+                "CLOUD",
             ]
         ):
             raise ValueError(
-                "must be one of enum values ('API', 'AI_MODEL', 'VECTOR_DB', 'RELATIONAL_DB', 'MESSAGE_BROKER', 'GIT', 'EMAIL', 'MCP')"
+                "must be one of enum values ('API', 'AI_MODEL', 'VECTOR_DB', 'RELATIONAL_DB', 'MESSAGE_BROKER', 'GIT', 'EMAIL', 'MCP', 'CLOUD')"
             )
         return value
 

--- a/src/conductor/asyncio_client/adapters/models/integration_adapter.py
+++ b/src/conductor/asyncio_client/adapters/models/integration_adapter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from pydantic import field_validator
 from typing_extensions import Self
 
 from conductor.asyncio_client.http.models import Integration
@@ -11,6 +12,29 @@ class IntegrationAdapter(Integration):
     apis: Optional[List["IntegrationApiAdapter"]] = None
     configuration: Optional[Dict[str, Any]] = None
     tags: Optional[List["TagAdapter"]] = None
+
+    @field_validator("category")
+    def category_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(
+            [
+                "API",
+                "AI_MODEL",
+                "VECTOR_DB",
+                "RELATIONAL_DB",
+                "MESSAGE_BROKER",
+                "GIT",
+                "EMAIL",
+                "MCP",
+            ]
+        ):
+            raise ValueError(
+                "must be one of enum values ('API', 'AI_MODEL', 'VECTOR_DB', 'RELATIONAL_DB', 'MESSAGE_BROKER', 'GIT', 'EMAIL', 'MCP')"
+            )
+        return value
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:
@@ -53,6 +77,8 @@ class IntegrationAdapter(Integration):
 from conductor.asyncio_client.adapters.models.integration_api_adapter import (  # noqa: E402
     IntegrationApiAdapter,
 )
-from conductor.asyncio_client.adapters.models.tag_adapter import TagAdapter  # noqa: E402
+from conductor.asyncio_client.adapters.models.tag_adapter import (
+    TagAdapter,
+)  # noqa: E402
 
 IntegrationAdapter.model_rebuild(raise_errors=False)

--- a/src/conductor/asyncio_client/adapters/models/integration_def_adapter.py
+++ b/src/conductor/asyncio_client/adapters/models/integration_def_adapter.py
@@ -26,10 +26,11 @@ class IntegrationDefAdapter(IntegrationDef):
                 "GIT",
                 "EMAIL",
                 "MCP",
+                "CLOUD",
             ]
         ):
             raise ValueError(
-                "must be one of enum values ('API', 'AI_MODEL', 'VECTOR_DB', 'RELATIONAL_DB', 'MESSAGE_BROKER', 'GIT', 'EMAIL', 'MCP')"
+                "must be one of enum values ('API', 'AI_MODEL', 'VECTOR_DB', 'RELATIONAL_DB', 'MESSAGE_BROKER', 'GIT', 'EMAIL', 'MCP', 'CLOUD')"
             )
         return value
 

--- a/src/conductor/asyncio_client/adapters/models/integration_def_form_field_adapter.py
+++ b/src/conductor/asyncio_client/adapters/models/integration_def_form_field_adapter.py
@@ -36,68 +36,85 @@ class IntegrationDefFormFieldAdapter(IntegrationDefFormField):
         if value not in set(
             [
                 "api_key",
-                "user",
-                "header",
-                "endpoint",
+                "authenticationType",
                 "authUrl",
-                "environment",
-                "projectName",
-                "indexName",
-                "publisher",
-                "password",
-                "namespace",
+                "awsAccountId",
+                "batchPollConsumersCount",
                 "batchSize",
                 "batchWaitTime",
-                "visibilityTimeout",
-                "connectionType",
-                "connectionPoolSize",
-                "consumer",
-                "stream",
-                "batchPollConsumersCount",
-                "consumer_type",
-                "region",
-                "awsAccountId",
-                "externalId",
-                "roleArn",
-                "protocol",
-                "mechanism",
-                "port",
-                "schemaRegistryUrl",
-                "schemaRegistryApiKey",
-                "schemaRegistryApiSecret",
-                "authenticationType",
-                "truststoreAuthenticationType",
-                "tls",
-                "cipherSuite",
-                "pubSubMethod",
-                "keyStorePassword",
-                "keyStoreLocation",
-                "schemaRegistryAuthType",
-                "valueSubjectNameStrategy",
-                "datasourceURL",
-                "jdbcDriver",
-                "subscription",
-                "serviceAccountCredentials",
-                "file",
-                "tlsFile",
-                "queueManager",
-                "groupId",
+                "betaVersion",
                 "channel",
+                "cipherSuite",
+                'completionsPath',
+                "connectionPoolSize",
+                "connectionType",
+                "consumer",
+                "consumer_type",
+                "datasourceURL",
                 "dimensions",
                 "distance_metric",
+                "endpoint",
+                "environment",
+                "externalId",
+                "file",
+                "groupId",
+                "header",
                 "indexing_method",
+                "indexName",
                 "inverted_list_count",
-                "pullPeriod",
-                "pullBatchWaitMillis",
-                "completionsPath",
-                "betaVersion",
-                "version",
+                "jdbcDriver",
+                "keyStoreLocation",
+                "keyStorePassword",
+                "mechanism",
+                "namespace",
                 "organizationId",
+                "password",
+                "port",
+                "projectName",
+                "protocol",
+                "pubSubMethod",
+                "publisher",
+                "pullBatchWaitMillis",
+                "pullPeriod",
+                "queueManager",
+                "region",
+                "roleArn",
+                "schemaRegistryApiKey",
+                "schemaRegistryApiSecret",
+                "schemaRegistryAuthType",
+                "schemaRegistryUrl",
+                "serviceAccountCredentials",
+                "stream",
+                "subscription",
+                "tls",
+                "tlsFile",
+                "truststoreAuthenticationType",
+                "user",
+                "valueSubjectNameStrategy",
+                "version",
+                "visibilityTimeout",
             ]
         ):
             raise ValueError(
-                "must be one of enum values ('api_key', 'user', 'endpoint', 'authUrl', 'environment', 'projectName', 'indexName', 'publisher', 'password', 'namespace', 'batchSize', 'batchWaitTime', 'visibilityTimeout', 'connectionType', 'consumer', 'stream', 'batchPollConsumersCount', 'consumer_type', 'region', 'awsAccountId', 'externalId', 'roleArn', 'protocol', 'mechanism', 'port', 'schemaRegistryUrl', 'schemaRegistryApiKey', 'schemaRegistryApiSecret', 'authenticationType', 'truststoreAuthenticationType', 'tls', 'cipherSuite', 'pubSubMethod', 'keyStorePassword', 'keyStoreLocation', 'schemaRegistryAuthType', 'valueSubjectNameStrategy', 'datasourceURL', 'jdbcDriver', 'subscription', 'serviceAccountCredentials', 'file', 'tlsFile', 'queueManager', 'groupId', 'channel', 'dimensions', 'distance_metric', 'indexing_method', 'inverted_list_count')"
+                "must be one of enum values ("
+                "'api_key', 'authenticationType', 'authUrl', 'awsAccountId', "
+                "'batchPollConsumersCount', 'batchSize', 'batchWaitTime', "
+                "'betaVersion', 'channel', 'cipherSuite', 'completionsPath', "
+                "'connectionPoolSize', 'connectionType', 'consumer', 'consumer_type', "
+                "'datasourceURL', 'dimensions', 'distance_metric', 'endpoint', "
+                "'environment', 'externalId', 'file', 'groupId', 'header', "
+                "'indexing_method', 'indexName', 'inverted_list_count', 'jdbcDriver', "
+                "'keyStoreLocation', 'keyStorePassword', 'mechanism', 'namespace', "
+                "'organizationId', 'password', 'port', 'projectName', 'protocol', "
+                "'pubSubMethod', 'publisher', 'pullBatchWaitMillis', 'pullPeriod', "
+                "'queueManager', 'region', 'roleArn', 'schemaRegistryApiKey', "
+                "'schemaRegistryApiSecret', 'schemaRegistryAuthType', 'schemaRegistryUrl', "
+                "'serviceAccountCredentials', 'stream', 'subscription', 'tls', 'tlsFile', "
+                "'truststoreAuthenticationType', 'user', 'valueSubjectNameStrategy', "
+                "'version', 'visibilityTimeout'"
+                ")"
             )
+
         return value
 
     @classmethod

--- a/src/conductor/asyncio_client/adapters/models/integration_def_form_field_adapter.py
+++ b/src/conductor/asyncio_client/adapters/models/integration_def_form_field_adapter.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, ClassVar, Dict, List, Optional
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from typing_extensions import Self
 
 from conductor.asyncio_client.http.models import IntegrationDefFormField
@@ -26,6 +26,78 @@ class IntegrationDefFormFieldAdapter(IntegrationDefFormField):
         "valueOptions",
         "dependsOn",
     ]
+
+    @field_validator("field_name")
+    def field_name_validate_enum(cls, value):
+        """Validates the enum"""
+        if value is None:
+            return value
+
+        if value not in set(
+            [
+                "api_key",
+                "user",
+                "header",
+                "endpoint",
+                "authUrl",
+                "environment",
+                "projectName",
+                "indexName",
+                "publisher",
+                "password",
+                "namespace",
+                "batchSize",
+                "batchWaitTime",
+                "visibilityTimeout",
+                "connectionType",
+                "connectionPoolSize",
+                "consumer",
+                "stream",
+                "batchPollConsumersCount",
+                "consumer_type",
+                "region",
+                "awsAccountId",
+                "externalId",
+                "roleArn",
+                "protocol",
+                "mechanism",
+                "port",
+                "schemaRegistryUrl",
+                "schemaRegistryApiKey",
+                "schemaRegistryApiSecret",
+                "authenticationType",
+                "truststoreAuthenticationType",
+                "tls",
+                "cipherSuite",
+                "pubSubMethod",
+                "keyStorePassword",
+                "keyStoreLocation",
+                "schemaRegistryAuthType",
+                "valueSubjectNameStrategy",
+                "datasourceURL",
+                "jdbcDriver",
+                "subscription",
+                "serviceAccountCredentials",
+                "file",
+                "tlsFile",
+                "queueManager",
+                "groupId",
+                "channel",
+                "dimensions",
+                "distance_metric",
+                "indexing_method",
+                "inverted_list_count",
+                "pullPeriod",
+                "pullBatchWaitMillis",
+                "completionsPath",
+                "betaVersion",
+                "version",
+            ]
+        ):
+            raise ValueError(
+                "must be one of enum values ('api_key', 'user', 'endpoint', 'authUrl', 'environment', 'projectName', 'indexName', 'publisher', 'password', 'namespace', 'batchSize', 'batchWaitTime', 'visibilityTimeout', 'connectionType', 'consumer', 'stream', 'batchPollConsumersCount', 'consumer_type', 'region', 'awsAccountId', 'externalId', 'roleArn', 'protocol', 'mechanism', 'port', 'schemaRegistryUrl', 'schemaRegistryApiKey', 'schemaRegistryApiSecret', 'authenticationType', 'truststoreAuthenticationType', 'tls', 'cipherSuite', 'pubSubMethod', 'keyStorePassword', 'keyStoreLocation', 'schemaRegistryAuthType', 'valueSubjectNameStrategy', 'datasourceURL', 'jdbcDriver', 'subscription', 'serviceAccountCredentials', 'file', 'tlsFile', 'queueManager', 'groupId', 'channel', 'dimensions', 'distance_metric', 'indexing_method', 'inverted_list_count')"
+            )
+        return value
 
     @classmethod
     def from_dict(cls, obj: Optional[Dict[str, Any]]) -> Optional[Self]:

--- a/src/conductor/asyncio_client/adapters/models/integration_def_form_field_adapter.py
+++ b/src/conductor/asyncio_client/adapters/models/integration_def_form_field_adapter.py
@@ -92,6 +92,7 @@ class IntegrationDefFormFieldAdapter(IntegrationDefFormField):
                 "completionsPath",
                 "betaVersion",
                 "version",
+                "organizationId",
             ]
         ):
             raise ValueError(

--- a/src/conductor/asyncio_client/event/event_client.py
+++ b/src/conductor/asyncio_client/event/event_client.py
@@ -1,5 +1,6 @@
-from conductor.asyncio_client.adapters.api.event_resource_api import \
-    EventResourceApiAdapter
+from conductor.asyncio_client.adapters.api.event_resource_api import (
+    EventResourceApiAdapter,
+)
 from conductor.asyncio_client.adapters import ApiClient
 from conductor.shared.event.configuration import QueueConfiguration
 

--- a/src/conductor/client/adapters/api_client_adapter.py
+++ b/src/conductor/client/adapters/api_client_adapter.py
@@ -10,14 +10,16 @@ logger = logging.getLogger(Configuration.get_logging_formatted_name(__name__))
 
 
 class ApiClientAdapter(ApiClient):
-    def __init__(
-        self, configuration=None, header_name=None, header_value=None, cookie=None
-    ):
+    def __init__(self, configuration=None, header_name=None, header_value=None, cookie=None):
         """Initialize the API client adapter with httpx-based REST client."""
-        super().__init__(configuration, header_name, header_value, cookie)
-        self.rest_client = RESTClientObjectAdapter(
-            connection=configuration.http_connection if configuration else None
-        )
+        self.configuration = configuration or Configuration()
+
+        # Create httpx-compatible REST client directly
+        self.rest_client = RESTClientObjectAdapter(connection=self.configuration.http_connection)
+
+        self.default_headers = self._ApiClient__get_default_headers(header_name, header_value)
+        self.cookie = cookie
+        self._ApiClient__refresh_auth_token()
 
     def __call_api(
         self,

--- a/src/conductor/client/adapters/models/integration_adapter.py
+++ b/src/conductor/client/adapters/models/integration_adapter.py
@@ -142,6 +142,7 @@ class IntegrationAdapter(Integration):
             "GIT",
             "EMAIL",
             "MCP",
+            "CLOUD",
         ]  # noqa: E501
         if category not in allowed_values:
             raise ValueError(

--- a/src/conductor/client/adapters/models/integration_def_adapter.py
+++ b/src/conductor/client/adapters/models/integration_def_adapter.py
@@ -102,6 +102,7 @@ class IntegrationDefAdapter(IntegrationDef):
             "GIT",
             "EMAIL",
             "MCP",
+            "CLOUD",
         ]  # noqa: E501
         if category not in allowed_values:
             raise ValueError(

--- a/src/conductor/client/adapters/models/integration_def_form_field_adapter.py
+++ b/src/conductor/client/adapters/models/integration_def_form_field_adapter.py
@@ -68,6 +68,7 @@ class IntegrationDefFormFieldAdapter(IntegrationDefFormField):
             "completionsPath",
             "betaVersion",
             "version",
+            "organizationId",
         ]
         if field_name not in allowed_values:
             raise ValueError(

--- a/src/conductor/client/adapters/models/integration_update_adapter.py
+++ b/src/conductor/client/adapters/models/integration_update_adapter.py
@@ -13,6 +13,7 @@ class IntegrationUpdateAdapter(IntegrationUpdate):
             "GIT",
             "EMAIL",
             "MCP",
+            "CLOUD",
         ]  # noqa: E501
         if category not in allowed_values:
             raise ValueError(

--- a/src/conductor/client/adapters/rest_adapter.py
+++ b/src/conductor/client/adapters/rest_adapter.py
@@ -74,6 +74,7 @@ class RESTClientObjectAdapter(RESTClientObject):
             timeout=httpx.Timeout(120.0),
             follow_redirects=True,
             limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
+            http2=True  # added explicit configuration
         )
 
     def close(self):

--- a/src/conductor/client/adapters/rest_adapter.py
+++ b/src/conductor/client/adapters/rest_adapter.py
@@ -71,7 +71,7 @@ class RESTClientObjectAdapter(RESTClientObject):
         """Initialize the REST client with httpx."""
         # Don't call super().__init__() to avoid requests initialization
         self.connection = connection or httpx.Client(
-            timeout=httpx.Timeout(120.0),
+            timeout=httpx.Timeout(300.0),
             follow_redirects=True,
             limits=httpx.Limits(max_keepalive_connections=20, max_connections=100),
             http2=True  # added explicit configuration

--- a/src/conductor/client/orkes/orkes_task_client.py
+++ b/src/conductor/client/orkes/orkes_task_client.py
@@ -87,7 +87,7 @@ class OrkesTaskClient(OrkesBaseClient, TaskClient):
         return queueSize
 
     def add_task_log(self, task_id: str, log_message: str):
-        self.taskResourceApi.log(log_message, task_id)
+        self.taskResourceApi.log(body=log_message, task_id=task_id)
 
     def get_task_logs(self, task_id: str) -> List[TaskExecLog]:
         return self.taskResourceApi.get_task_logs(task_id)

--- a/tests/integration/async/test_async_orkes_authorization_client_integration.py
+++ b/tests/integration/async/test_async_orkes_authorization_client_integration.py
@@ -6,6 +6,8 @@ import pytest_asyncio
 
 from conductor.asyncio_client.adapters.api_client_adapter import \
     ApiClientAdapter as ApiClient
+from conductor.asyncio_client.adapters.models.authorization_request_adapter import \
+    AuthorizationRequestAdapter as AuthorizationRequest
 from conductor.asyncio_client.adapters.models.create_or_update_application_request_adapter import \
     CreateOrUpdateApplicationRequestAdapter as CreateOrUpdateApplicationRequest
 from conductor.asyncio_client.adapters.models.subject_ref_adapter import \
@@ -23,7 +25,6 @@ from conductor.asyncio_client.http.models import tag
 from conductor.asyncio_client.http.rest import ApiException
 from conductor.asyncio_client.orkes.orkes_authorization_client import \
     OrkesAuthorizationClient
-from conductor.asyncio_client.adapters.models.authorization_request_adapter import AuthorizationRequestAdapter as AuthorizationRequest
 from conductor.client.orkes.models.access_key_status import AccessKeyStatus
 from conductor.client.orkes.models.access_type import AccessType
 from conductor.shared.http.enums.subject_type import SubjectType
@@ -59,7 +60,6 @@ class TestOrkesAuthorizationClientIntegration:
         """Create OrkesAuthorizationClient instance."""
         async with ApiClient(configuration) as api_client:
             return OrkesAuthorizationClient(configuration, api_client=api_client)
-
 
     @pytest.fixture(scope="class")
     def test_suffix(self) -> str:
@@ -113,7 +113,7 @@ class TestOrkesAuthorizationClientIntegration:
             updated_name = f"{test_application_name}_updated"
             update_request = CreateOrUpdateApplicationRequest(name=updated_name)
             updated_app = await auth_client.update_application(
-                created_app.id,update_request
+                created_app.id, update_request
             )
             assert updated_app.name == updated_name
 
@@ -227,7 +227,7 @@ class TestOrkesAuthorizationClientIntegration:
                 description="Test Group", roles=["USER"]
             )
             created_group = await auth_client.upsert_group(
-                test_group_id, create_request 
+                test_group_id, create_request
             )
 
             assert created_group.id == test_group_id
@@ -298,12 +298,22 @@ class TestOrkesAuthorizationClientIntegration:
             group_subject = SubjectRef(id=test_group_id, type=SubjectType.GROUP)
 
             user_access = [AccessType.EXECUTE, AccessType.READ]
-            await auth_client.grant_permissions(AuthorizationRequest(subject=user_subject, target=target, access=user_access))
+            await auth_client.grant_permissions(
+                AuthorizationRequest(
+                    subject=user_subject, target=target, access=user_access
+                )
+            )
 
             group_access = [AccessType.READ]
-            await auth_client.grant_permissions(AuthorizationRequest(subject=group_subject, target=target, access=group_access))
+            await auth_client.grant_permissions(
+                AuthorizationRequest(
+                    subject=group_subject, target=target, access=group_access
+                )
+            )
 
-            target_permissions = await auth_client.get_permissions(target.type, target.id)
+            target_permissions = await auth_client.get_permissions(
+                target.type, target.id
+            )
 
             assert AccessType.EXECUTE in target_permissions
             assert AccessType.READ in target_permissions
@@ -349,25 +359,38 @@ class TestOrkesAuthorizationClientIntegration:
             assert len(group_target_perms) >= 1
             assert AccessType.READ in group_target_perms[0].access
 
-            await auth_client.remove_permissions(AuthorizationRequest(subject=user_subject, target=target, access=user_access))
-            await auth_client.remove_permissions(AuthorizationRequest(subject=group_subject, target=target, access=group_access))
+            await auth_client.remove_permissions(
+                AuthorizationRequest(
+                    subject=user_subject, target=target, access=user_access
+                )
+            )
+            await auth_client.remove_permissions(
+                AuthorizationRequest(
+                    subject=group_subject, target=target, access=group_access
+                )
+            )
 
-            target_permissions_after = await auth_client.get_permissions(target.type, target.id)
+            target_permissions_after = await auth_client.get_permissions(
+                target.type, target.id
+            )
             if AccessType.EXECUTE in target_permissions_after:
                 user_perms_after = target_permissions_after[AccessType.EXECUTE]
                 assert not any(
-                    subject["id"] == test_user_id and subject["type"] == SubjectType.USER
+                    subject["id"] == test_user_id
+                    and subject["type"] == SubjectType.USER
                     for subject in user_perms_after
                 )
 
             if AccessType.READ in target_permissions_after:
                 read_perms_after = target_permissions_after[AccessType.READ]
                 assert not any(
-                    subject["id"] == test_user_id and subject["type"] == SubjectType.USER
+                    subject["id"] == test_user_id
+                    and subject["type"] == SubjectType.USER
                     for subject in read_perms_after
                 )
                 assert not any(
-                    subject["id"] == test_group_id and subject["type"] == SubjectType.GROUP
+                    subject["id"] == test_group_id
+                    and subject["type"] == SubjectType.GROUP
                     for subject in read_perms_after
                 )
 
@@ -549,7 +572,11 @@ class TestOrkesAuthorizationClientIntegration:
                     id=main_groups["worker"].id, type=SubjectType.GROUP
                 )
                 await auth_client.grant_permissions(
-                    AuthorizationRequest(subject=exec_subject, target=workflow_target, access=[AccessType.EXECUTE, AccessType.READ, AccessType.CREATE])
+                    AuthorizationRequest(
+                        subject=exec_subject,
+                        target=workflow_target,
+                        access=[AccessType.EXECUTE, AccessType.READ, AccessType.CREATE],
+                    )
                 )
                 created_resources["permissions"].append(
                     (
@@ -563,7 +590,11 @@ class TestOrkesAuthorizationClientIntegration:
                     id=main_groups["metadata_manager"].id, type=SubjectType.GROUP
                 )
                 await auth_client.grant_permissions(
-                    AuthorizationRequest(subject=manager_subject, target=workflow_target, access=[AccessType.EXECUTE, AccessType.READ])
+                    AuthorizationRequest(
+                        subject=manager_subject,
+                        target=workflow_target,
+                        access=[AccessType.EXECUTE, AccessType.READ],
+                    )
                 )
                 created_resources["permissions"].append(
                     (
@@ -577,10 +608,14 @@ class TestOrkesAuthorizationClientIntegration:
                     id=main_groups["user"].id, type=SubjectType.GROUP
                 )
                 await auth_client.grant_permissions(
-                    AuthorizationRequest(subject=emp_subject, target=workflow_target, access=[AccessType.READ])
+                    AuthorizationRequest(
+                        subject=emp_subject,
+                        target=workflow_target,
+                        access=[AccessType.READ],
+                    )
                 )
                 created_resources["permissions"].append(
-                    (emp_subject, workflow_target, [AccessType.READ]) 
+                    (emp_subject, workflow_target, [AccessType.READ])
                 )
 
             for dept in departments:
@@ -591,7 +626,11 @@ class TestOrkesAuthorizationClientIntegration:
                 )
 
                 await auth_client.grant_permissions(
-                    AuthorizationRequest(subject=dept_group_subject, target=dept_target, access=[AccessType.CREATE, AccessType.EXECUTE, AccessType.READ])
+                    AuthorizationRequest(
+                        subject=dept_group_subject,
+                        target=dept_target,
+                        access=[AccessType.CREATE, AccessType.EXECUTE, AccessType.READ],
+                    )
                 )
                 created_resources["permissions"].append(
                     (
@@ -627,7 +666,9 @@ class TestOrkesAuthorizationClientIntegration:
                 workflow_target = TargetRef(
                     id=workflow_name, type=TargetType.WORKFLOW_DEF
                 )
-                permissions = await auth_client.get_permissions(workflow_target.type, workflow_target.id)
+                permissions = await auth_client.get_permissions(
+                    workflow_target.type, workflow_target.id
+                )
 
                 if AccessType.EXECUTE in permissions:
                     exec_perms = permissions[AccessType.EXECUTE]
@@ -675,7 +716,11 @@ class TestOrkesAuthorizationClientIntegration:
 
         for subject, target, access_types in created_resources["permissions"]:
             try:
-                auth_client.remove_permissions(AuthorizationRequest(subject=subject, target=target, access=access_types))
+                auth_client.remove_permissions(
+                    AuthorizationRequest(
+                        subject=subject, target=target, access=access_types
+                    )
+                )
             except Exception as e:
                 print(
                     f"Warning: Failed to remove permission {subject.id} -> {target.id}: {str(e)}"

--- a/tests/integration/async/test_async_orkes_authorization_client_integration.py
+++ b/tests/integration/async/test_async_orkes_authorization_client_integration.py
@@ -716,7 +716,7 @@ class TestOrkesAuthorizationClientIntegration:
 
         for subject, target, access_types in created_resources["permissions"]:
             try:
-                auth_client.remove_permissions(
+                await auth_client.remove_permissions(
                     AuthorizationRequest(
                         subject=subject, target=target, access=access_types
                     )

--- a/tests/integration/async/test_async_orkes_task_client_integration.py
+++ b/tests/integration/async/test_async_orkes_task_client_integration.py
@@ -399,8 +399,8 @@ class TestOrkesTaskClientIntegration:
 
         finally:
             try:
-                metadata_client.unregister_task_def(test_task_type)
-                metadata_client.unregister_workflow_def(test_workflow_name, 1)
+                await metadata_client.unregister_task_def(test_task_type)
+                await metadata_client.unregister_workflow_def(test_workflow_name, 1)
             except Exception:
                 pass
 

--- a/tests/integration/async/test_async_orkes_workflow_client_integration.py
+++ b/tests/integration/async/test_async_orkes_workflow_client_integration.py
@@ -797,7 +797,9 @@ class TestOrkesWorkflowClientIntegration:
         finally:
             for workflow_id in workflow_ids:
                 try:
-                    await workflow_client.delete_workflow(workflow_id, archive_workflow=True)
+                    await workflow_client.delete_workflow(
+                        workflow_id, archive_workflow=True
+                    )
                 except Exception as e:
                     print(
                         f"Warning: Failed to cleanup workflow {workflow_id}: {str(e)}"
@@ -840,7 +842,9 @@ class TestOrkesWorkflowClientIntegration:
         finally:
             if workflow_id:
                 try:
-                    await workflow_client.delete_workflow(workflow_id, archive_workflow=True)
+                    await workflow_client.delete_workflow(
+                        workflow_id, archive_workflow=True
+                    )
                 except Exception as e:
                     print(
                         f"Warning: Failed to cleanup workflow {workflow_id}: {str(e)}"

--- a/tests/integration/async/test_async_orkes_workflow_client_integration.py
+++ b/tests/integration/async/test_async_orkes_workflow_client_integration.py
@@ -797,7 +797,7 @@ class TestOrkesWorkflowClientIntegration:
         finally:
             for workflow_id in workflow_ids:
                 try:
-                    workflow_client.delete_workflow(workflow_id, archive_workflow=True)
+                    await workflow_client.delete_workflow(workflow_id, archive_workflow=True)
                 except Exception as e:
                     print(
                         f"Warning: Failed to cleanup workflow {workflow_id}: {str(e)}"
@@ -840,7 +840,7 @@ class TestOrkesWorkflowClientIntegration:
         finally:
             if workflow_id:
                 try:
-                    workflow_client.delete_workflow(workflow_id, archive_workflow=True)
+                    await workflow_client.delete_workflow(workflow_id, archive_workflow=True)
                 except Exception as e:
                     print(
                         f"Warning: Failed to cleanup workflow {workflow_id}: {str(e)}"

--- a/tests/integration/async/test_async_orkes_workflow_client_integration.py
+++ b/tests/integration/async/test_async_orkes_workflow_client_integration.py
@@ -281,7 +281,7 @@ class TestOrkesWorkflowClientIntegration:
             workflow_run = await workflow_client.execute_workflow(
                 start_workflow_request=simple_start_workflow_request,
                 request_id=f"execute_sync_{str(uuid.uuid4())[:8]}",
-                wait_for_seconds=30,
+                wait_for_seconds=10,
             )
 
             assert workflow_run is not None
@@ -305,7 +305,7 @@ class TestOrkesWorkflowClientIntegration:
                 await workflow_client.execute_workflow_with_return_strategy(
                     start_workflow_request=simple_start_workflow_request,
                     request_id=f"execute_strategy_{str(uuid.uuid4())[:8]}",
-                    wait_for_seconds=30,
+                    wait_for_seconds=10,
                 )
             )
 
@@ -876,7 +876,7 @@ class TestOrkesWorkflowClientIntegration:
                 workflow_id=workflow_id,
                 workflow_state_update=state_update,
                 wait_until_task_ref_name="test_task_ref",
-                wait_for_seconds=30,
+                wait_for_seconds=10,
             )
 
             assert workflow_run is not None

--- a/tests/integration/test_conductor_oss_workflow_integration.py
+++ b/tests/integration/test_conductor_oss_workflow_integration.py
@@ -3,6 +3,7 @@ import time
 import uuid
 
 import pytest
+import httpx
 
 from conductor.client.http.models.rerun_workflow_request import (
     RerunWorkflowRequestAdapter as RerunWorkflowRequest,
@@ -41,6 +42,12 @@ class TestConductorOssWorkflowIntegration:
     def configuration(self) -> Configuration:
         """Create configuration for Conductor OSS."""
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_authorization_client_integration.py
+++ b/tests/integration/test_orkes_authorization_client_integration.py
@@ -2,6 +2,7 @@ import os
 import uuid
 
 import pytest
+import httpx
 
 from conductor.client.http.models.create_or_update_application_request import \
     CreateOrUpdateApplicationRequestAdapter as CreateOrUpdateApplicationRequest
@@ -41,6 +42,12 @@ class TestOrkesAuthorizationClientIntegration:
     def configuration(self) -> Configuration:
         """Create configuration from environment variables."""
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_integration_client_integration.py
+++ b/tests/integration/test_orkes_integration_client_integration.py
@@ -3,6 +3,7 @@ import pytest
 import uuid
 import threading
 import time
+import httpx
 
 from conductor.client.configuration.configuration import Configuration
 from conductor.client.orkes.orkes_integration_client import OrkesIntegrationClient
@@ -32,6 +33,12 @@ class TestOrkesIntegrationClientIntegration:
     @pytest.fixture(scope="class")
     def configuration(self) -> Configuration:
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_metadata_client_integration.py
+++ b/tests/integration/test_orkes_metadata_client_integration.py
@@ -2,6 +2,7 @@ import os
 import uuid
 
 import pytest
+import httpx
 
 from conductor.client.http.models.task_def import \
     TaskDefAdapter as TaskDef
@@ -31,6 +32,12 @@ class TestOrkesMetadataClientIntegration:
     @pytest.fixture(scope="class")
     def configuration(self) -> Configuration:
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_prompt_client_integration.py
+++ b/tests/integration/test_orkes_prompt_client_integration.py
@@ -2,6 +2,7 @@ import os
 import uuid
 
 import pytest
+import httpx
 
 from conductor.client.codegen.rest import ApiException
 from conductor.client.configuration.configuration import Configuration
@@ -25,6 +26,12 @@ class TestOrkesPromptClientIntegration:
     @pytest.fixture(scope="class")
     def configuration(self) -> Configuration:
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_prompt_client_integration.py
+++ b/tests/integration/test_orkes_prompt_client_integration.py
@@ -3,8 +3,8 @@ import uuid
 
 import pytest
 
-from conductor.client.configuration.configuration import Configuration
 from conductor.client.codegen.rest import ApiException
+from conductor.client.configuration.configuration import Configuration
 from conductor.client.orkes.models.metadata_tag import MetadataTag
 from conductor.client.orkes.orkes_prompt_client import OrkesPromptClient
 

--- a/tests/integration/test_orkes_scheduler_client_integration.py
+++ b/tests/integration/test_orkes_scheduler_client_integration.py
@@ -3,6 +3,7 @@ import time
 import uuid
 
 import pytest
+import httpx
 
 from conductor.client.http.models.save_schedule_request import \
     SaveScheduleRequestAdapter as SaveScheduleRequest
@@ -30,6 +31,12 @@ class TestOrkesSchedulerClientIntegration:
     @pytest.fixture(scope="class")
     def configuration(self) -> Configuration:
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_schema_client_integration.py
+++ b/tests/integration/test_orkes_schema_client_integration.py
@@ -3,6 +3,7 @@ import uuid
 from copy import deepcopy
 
 import pytest
+import httpx
 
 from conductor.client.http.models.schema_def import \
     SchemaDefAdapter as SchemaDef
@@ -28,6 +29,12 @@ class TestOrkesSchemaClientIntegration:
     @pytest.fixture(scope="class")
     def configuration(self) -> Configuration:
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_secret_client_integration.py
+++ b/tests/integration/test_orkes_secret_client_integration.py
@@ -1,8 +1,8 @@
 import os
 import uuid
-from copy import deepcopy
 
 import pytest
+import httpx
 
 from conductor.client.configuration.configuration import Configuration
 from conductor.client.codegen.rest import ApiException
@@ -26,6 +26,12 @@ class TestOrkesSecretClientIntegration:
     @pytest.fixture(scope="class")
     def configuration(self) -> Configuration:
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_service_registry_client_integration.py
+++ b/tests/integration/test_orkes_service_registry_client_integration.py
@@ -2,6 +2,7 @@ import os
 import uuid
 
 import pytest
+import httpx
 
 from conductor.client.http.models.request_param import (
     RequestParamAdapter as RequestParam,
@@ -40,6 +41,12 @@ class TestOrkesServiceRegistryClientIntegration:
     @pytest.fixture(scope="class")
     def configuration(self) -> Configuration:
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_task_client_integration.py
+++ b/tests/integration/test_orkes_task_client_integration.py
@@ -725,8 +725,8 @@ class TestOrkesTaskClientIntegration:
                 )
                 if notification_task:
                     task_client.add_task_log(
-                        notification_task.task_id,
-                        f"Sending notification for workflow {workflow_id}",
+                        task_id=notification_task.task_id,
+                        log_message=f"Sending notification for workflow {workflow_id}",
                     )
 
                     notification_result = TaskResult(

--- a/tests/integration/test_orkes_task_client_integration.py
+++ b/tests/integration/test_orkes_task_client_integration.py
@@ -5,18 +5,17 @@ import uuid
 
 import pytest
 
+from conductor.client.codegen.rest import ApiException
+from conductor.client.configuration.configuration import Configuration
+from conductor.client.http.models import task
 from conductor.client.http.models.start_workflow_request import \
     StartWorkflowRequestAdapter as StartWorkflowRequest
-from conductor.client.http.models.task_def import \
-    TaskDefAdapter as TaskDef
+from conductor.client.http.models.task_def import TaskDefAdapter as TaskDef
 from conductor.client.http.models.task_result import \
     TaskResultAdapter as TaskResult
-from conductor.client.http.models.workflow import \
-    WorkflowAdapter as Workflow
+from conductor.client.http.models.workflow import WorkflowAdapter as Workflow
 from conductor.client.http.models.workflow_def import \
     WorkflowDefAdapter as WorkflowDef
-from conductor.client.configuration.configuration import Configuration
-from conductor.client.codegen.rest import ApiException
 from conductor.client.orkes.orkes_metadata_client import OrkesMetadataClient
 from conductor.client.orkes.orkes_task_client import OrkesTaskClient
 from conductor.client.orkes.orkes_workflow_client import OrkesWorkflowClient
@@ -688,7 +687,8 @@ class TestOrkesTaskClientIntegration:
                 )
                 if data_task:
                     task_client.add_task_log(
-                        data_task.task_id, f"Processing data for workflow {workflow_id}"
+                        task_id=data_task.task_id,
+                        log_message=f"Processing data for workflow {workflow_id}",
                     )
 
                     data_result = TaskResult(
@@ -706,8 +706,8 @@ class TestOrkesTaskClientIntegration:
                 )
                 if validation_task:
                     task_client.add_task_log(
-                        validation_task.task_id,
-                        f"Validating data for workflow {workflow_id}",
+                        task_id=validation_task.task_id,
+                        log_message=f"Validating data for workflow {workflow_id}",
                     )
 
                     validation_result = TaskResult(
@@ -743,7 +743,8 @@ class TestOrkesTaskClientIntegration:
                 )
                 if cleanup_task:
                     task_client.add_task_log(
-                        cleanup_task.task_id, f"Cleaning up for workflow {workflow_id}"
+                        task_id=cleanup_task.task_id,
+                        log_message=f"Cleaning up for workflow {workflow_id}",
                     )
                     cleanup_result = TaskResult(
                         workflow_instance_id=workflow_id,

--- a/tests/integration/test_orkes_task_client_integration.py
+++ b/tests/integration/test_orkes_task_client_integration.py
@@ -700,6 +700,9 @@ class TestOrkesTaskClientIntegration:
                     task_client.update_task(data_result)
                     created_resources["tasks"].append(data_task.task_id)
 
+                # Wait for workflow to process data task completion and schedule validation task
+                time.sleep(2)
+
                 validation_task = task_client.poll_task(
                     f"validation_task_{test_suffix}",
                     worker_id=f"worker_{test_suffix}_{i}",
@@ -719,6 +722,9 @@ class TestOrkesTaskClientIntegration:
                     task_client.update_task(validation_result)
                     created_resources["tasks"].append(validation_task.task_id)
 
+                # Wait for workflow to process validation task completion and schedule notification task
+                time.sleep(2)
+
                 notification_task = task_client.poll_task(
                     f"notification_task_{test_suffix}",
                     worker_id=f"worker_{test_suffix}_{i}",
@@ -737,6 +743,8 @@ class TestOrkesTaskClientIntegration:
                     )
                     task_client.update_task(notification_result)
                     created_resources["tasks"].append(notification_task.task_id)
+
+                time.sleep(2)
 
                 cleanup_task = task_client.poll_task(
                     f"cleanup_task_{test_suffix}", worker_id=f"worker_{test_suffix}_{i}"

--- a/tests/integration/test_orkes_task_client_integration.py
+++ b/tests/integration/test_orkes_task_client_integration.py
@@ -4,6 +4,7 @@ import time
 import uuid
 
 import pytest
+import httpx
 
 from conductor.client.codegen.rest import ApiException
 from conductor.client.configuration.configuration import Configuration
@@ -39,6 +40,12 @@ class TestOrkesTaskClientIntegration:
     def configuration(self) -> Configuration:
         """Create configuration from environment variables."""
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/integration/test_orkes_workflow_client_integration.py
+++ b/tests/integration/test_orkes_workflow_client_integration.py
@@ -3,6 +3,7 @@ import time
 import uuid
 
 import pytest
+import httpx
 
 from conductor.client.http.models.correlation_ids_search_request import \
     CorrelationIdsSearchRequestAdapter as CorrelationIdsSearchRequest
@@ -40,6 +41,12 @@ class TestOrkesWorkflowClientIntegration:
     @pytest.fixture(scope="class")
     def configuration(self) -> Configuration:
         config = Configuration()
+        config.http_connection = httpx.Client(
+            timeout=httpx.Timeout(600.0),
+            follow_redirects=True,
+            limits=httpx.Limits(max_keepalive_connections=1, max_connections=1),
+            http2=True
+        )
         config.debug = os.getenv("CONDUCTOR_DEBUG", "false").lower() == "true"
         config.apply_logging_config()
         return config

--- a/tests/unit/orkes/test_task_client.py
+++ b/tests/unit/orkes/test_task_client.py
@@ -201,7 +201,7 @@ def test_add_task_log(mocker, task_client):
     mock = mocker.patch.object(TaskResourceApi, "log")
     log_message = "Test log"
     task_client.add_task_log(TASK_ID, log_message)
-    mock.assert_called_with(log_message, TASK_ID)
+    mock.assert_called_with(body=log_message, task_id=TASK_ID)
 
 
 def test_get_task_logs(mocker, task_client):


### PR DESCRIPTION
Changes:

1. Updated check test results CI step to include integration tests
2. Updated IntegrationDef adapters for both sync and async client to include `CLOUD` category option
3. Updated IntegrationDefFormFieldAdapter to include `organizationId` field_name

Reason:
1. Сheck results step did not include verification of the completion of integration tests, so CI did not fail in the event of integration tests failing
2-3. Test cluster has been updated to version 5.2.20, which includes a new `CLOUD` category and a new field `organizationId`. Due to the absence of these values in the SDK, the tests failed.