### PR TITLE
Updated pyproject toml to remove py3.13 limitation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1963,5 +1963,5 @@ propcache = ">=0.2.1"
 
 [metadata]
 lock-version = "2.1"
-python-versions = ">=3.9,<3.13"
-content-hash = "2d36acfc3e5cbafdea8125054c76dac80fd1c4a9fb78b2a72fb2ca942ad60c92"
+python-versions = ">=3.9"
+content-hash = "143daf87979e591c10779700ba2910a80adb2fbd96b68ad2004d093690cb7c85"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.9"
 certifi = ">=14.05.14"
 prometheus-client = ">=0.13.1"
 six = ">=1.10"


### PR DESCRIPTION
Changes:
* Removed limitation for python 3.13 in pyproject.toml

Reason:
* Keep backward compatibility with previous package versions
* Enable forward compatibility with Python 3.13+. The <3.13 restriction was overly conservative and all dependencies support Python 3.13.