### PR TITLE
fix: correct WaitTask inputParameter key from 'wait_until' to 'until'

### DIFF
--- a/src/conductor/client/workflow/task/wait_task.py
+++ b/src/conductor/client/workflow/task/wait_task.py
@@ -22,7 +22,7 @@ class WaitTask(TaskInterface, ABC):
             raise Exception("both wait_until and wait_for_seconds are provided.  ONLY one is allowed")
         if wait_until:
             self.input_parameters = {
-                "wait_until": wait_until
+                "until": wait_until
             }
         if wait_for_seconds:
             self.input_parameters = {

--- a/tests/unit/workflow/test_wait_task.py
+++ b/tests/unit/workflow/test_wait_task.py
@@ -1,0 +1,40 @@
+import unittest
+
+from conductor.client.workflow.task.wait_task import WaitTask, WaitForDurationTask, WaitUntilTask
+
+
+class TestWaitTask(unittest.TestCase):
+    def test_wait_until_uses_correct_key(self):
+        """WaitTask(wait_until=...) must set the 'until' key, not 'wait_until'.
+
+        The Conductor server reads the 'until' inputParameter (see Wait.java:
+        UNTIL_INPUT = "until").  Using the wrong key causes the task to stay
+        IN_PROGRESS indefinitely because the server never evaluates the
+        condition.  See: https://github.com/conductor-oss/python-sdk/issues/426
+        """
+        task = WaitTask("my_wait_ref", wait_until="2025-01-01 00:00 UTC")
+        self.assertIn("until", task.input_parameters)
+        self.assertNotIn("wait_until", task.input_parameters)
+        self.assertEqual(task.input_parameters["until"], "2025-01-01 00:00 UTC")
+
+    def test_wait_for_seconds_uses_duration_key(self):
+        task = WaitTask("my_wait_ref", wait_for_seconds=30)
+        self.assertIn("duration", task.input_parameters)
+        self.assertEqual(task.input_parameters["duration"], "30s")
+
+    def test_both_params_raises(self):
+        with self.assertRaises(Exception):
+            WaitTask("my_wait_ref", wait_until="2025-01-01 00:00 UTC", wait_for_seconds=30)
+
+    def test_wait_for_duration_task(self):
+        task = WaitForDurationTask("dur_ref", duration_time_seconds=60)
+        self.assertEqual(task.input_parameters["duration"], "60s")
+
+    def test_wait_until_task_uses_until_key(self):
+        task = WaitUntilTask("until_ref", date_time="2025-06-01 12:00 UTC")
+        self.assertIn("until", task.input_parameters)
+        self.assertEqual(task.input_parameters["until"], "2025-06-01 12:00 UTC")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #426.

`WaitTask.__init__(wait_until=...)` was setting the `inputParameter` key as `"wait_until"`, but the Conductor server reads `"until"` (see `Wait.java`: `UNTIL_INPUT = "until"`). This caused any workflow using `WaitTask(wait_until=...)` directly to stay `RUNNING`/`IN_PROGRESS` indefinitely — the server never evaluated the wait condition.

- **Root cause:** one-line typo in `wait_task.py` line 25: `"wait_until"` → `"until"`
- **Scope:** Only `WaitTask.__init__()` called with `wait_until=` was affected. `WaitUntilTask` already used the correct key and is unchanged.

## Changes

- `src/conductor/client/workflow/task/wait_task.py` — fix the wrong key (`"wait_until"` → `"until"`)
- `tests/unit/workflow/test_wait_task.py` — add unit tests for `WaitTask`, `WaitForDurationTask`, and `WaitUntilTask` to prevent regressions

## Test plan

- [ ] `pytest tests/unit/workflow/test_wait_task.py` — all 5 tests pass
- [ ] `WaitTask("ref", wait_until="2025-01-01 00:00 UTC").input_parameters` returns `{"until": "2025-01-01 00:00 UTC"}` (not `"wait_until"`)
- [ ] Existing `WaitUntilTask` and `WaitForDurationTask` behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)