### PR TITLE
Fix 09c_hitl_streaming: approval pause never fires

### DIFF
--- a/examples/agents/09c_hitl_streaming.py
+++ b/examples/agents/09c_hitl_streaming.py
@@ -41,9 +41,14 @@ agent = Agent(
     model=settings.llm_model,
     tools=[check_service, restart_service, delete_service_data],
     instructions=(
-        "You are an operations assistant. You can check, restart, and manage services. "
-        "If a service is unhealthy, check it first, then restart it. Only suggest "
-        "deleting data if explicitly asked."
+        "You are an operations assistant. Work through the request one tool call at a "
+        "time, in this order:\n"
+        "1. Check the service with check_service.\n"
+        "2. If it is unhealthy, restart it with restart_service.\n"
+        "3. Last, if the user asked you to clear or delete data, call "
+        "delete_service_data.\n"
+        "A human approves the deletion, not you — delete_service_data pauses for that "
+        "approval by itself, so never ask for approval in your own reply."
     ),
 )
 


### PR DESCRIPTION
The agent's instructions said "Only **suggest** deleting data if explicitly asked", so the model returned the approval question as its final answer (`finishReason: STOP`) instead of calling the tool. No `WAITING` event was emitted, so the example's approval handler never ran and the `approval_required=True` pause it exists to demonstrate never fired (0/6 runs).

Reworded as ordered steps that name the tool and leave approval to the gate.

Verified 4/4 — `openai/gpt-4o-mini` 2/2, `anthropic/claude-sonnet-4-5` 2/2:
check → restart → approval pause → delete.

Why not a one-word `suggest`→`delete` fix: any prose phrasing states the deletion as a permission, and `gpt-4o-mini` treats a permission as optional — it restarts, reports success, and skips the tool (0/5 across two prose variants). Numbered imperative steps get it executed.