### PR TITLE
Fix two examples that break under the spawn start method

### DIFF
--- a/examples/agents/16k_credentials_google_adk.py
+++ b/examples/agents/16k_credentials_google_adk.py
@@ -17,6 +17,19 @@ Requirements:
 import os
 
 from conductor.ai.agents import AgentRuntime
+from settings import settings
+
+
+# Tools must be defined at module level, not nested inside the factory below.
+# Workers are dispatched to processes started with the default "spawn" method, which
+# re-imports the callable by qualified name — a closure cannot be pickled that way and
+# registration fails before the workflow starts.
+def check_github_auth() -> str:
+    """Check if GitHub authentication is available."""
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        return f"GitHub token is set (starts with {token[:4]}...)"
+    return "GitHub token is NOT set"
 
 
 def create_adk_agent():
@@ -24,16 +37,11 @@ def create_adk_agent():
     from google.adk import Agent
     from google.adk.tools import FunctionTool
 
-    def check_github_auth() -> str:
-        """Check if GitHub authentication is available."""
-        token = os.environ.get("GITHUB_TOKEN", "")
-        if token:
-            return f"GitHub token is set (starts with {token[:4]}...)"
-        return "GitHub token is NOT set"
-
     agent = Agent(
         name="github_checker",
-        model="gemini-2.5-flash",
+        # The Conductor server runs the LLM call, so this takes the same
+        # "provider/model" string as every other example.
+        model=settings.llm_model,
         instruction="You check GitHub authentication status.",
         tools=[FunctionTool(check_github_auth)],
     )

--- a/examples/agents/39c_serverless_code_execution.py
+++ b/examples/agents/39c_serverless_code_execution.py
@@ -64,8 +64,6 @@ def _start_mock_server(port: int = 9753) -> HTTPServer:
 
 # ── Agent setup ───────────────────────────────────────────────────────
 
-mock_server = _start_mock_server(port=9753)
-
 serverless_coder = Agent(
     name="serverless_coder",
     model=settings.llm_model,
@@ -84,6 +82,12 @@ serverless_coder = Agent(
 
 
 if __name__ == "__main__":
+    # Started here rather than at module level: worker processes are launched with
+    # the default "spawn" start method, which re-imports this module in a fresh
+    # interpreter. A module-level start would try to bind 127.0.0.1:9753 a second
+    # time in every worker and fail with "Address already in use".
+    mock_server = _start_mock_server(port=9753)
+
     with AgentRuntime() as runtime:
         print("--- Serverless Code Execution ---")
         result = runtime.run(


### PR DESCRIPTION
Worker processes are launched with the default `spawn` start method, which re-imports the module in a fresh interpreter. Two examples relied on state that only survives `fork`:

**16k** — `check_github_auth` was a closure inside `create_adk_agent()`, so a worker could not be pickled by qualified name and registration failed before any workflow started:

```
SpawnSafetyError: worker 'check_github_auth' is not spawn-safe
(AttributeError("Can't get local object 'create_adk_agent.<locals>.check_github_auth'"))
```

Moved to module level. Verified: tool task COMPLETED with `{"result": "GitHub token is set (starts with ghp_...)"}`, so the worker registered, executed, and received its injected credential. Needs `CONDUCTOR_SECRET_GITHUB_TOKEN` in the server env.

**39c** — `_start_mock_server(port=9753)` ran at module level, so every worker re-bound the port. The example hung indefinitely (>6m40s with no output past its header). Moved inside `__main__`. Verified: now completes with `2**100 = 1267650600228229401496703205376`, `Tool calls: 1`, `FinishReason.STOP`.

Same class as #450/#451.

Also replaces 16k's hardcoded `model="gemini-2.5-flash"` with `settings.llm_model`: it routed to Vertex AI (no Google credentials), contradicted the file's own docstring, and every sibling framework example already reads `settings.llm_model`.