### PR TITLE
Fix 13_hierarchical_agents: restore the demo, stop blocking on serve()

### DIFF
--- a/examples/agents/13_hierarchical_agents.py
+++ b/examples/agents/13_hierarchical_agents.py
@@ -110,9 +110,12 @@ ceo = Agent(
 if __name__ == "__main__":
     with AgentRuntime() as runtime:
         print("--- Technical question (CEO -> Engineering -> Backend) ---")
-        # result = runtime.run(ceo, "Design a REST API for a user management system with authentication "
-        #                          "and then ask marketing team to come up with a marketing campaign for the system with details on how to run these campaign")
-        # result.print_result()
+        result = runtime.run(
+            ceo,
+            "Design a REST API for a user management system with authentication, "
+            "then ask the marketing team for a campaign to promote it.",
+        )
+        result.print_result()
 
         # Production pattern:
         # 1. Deploy once during CI/CD:
@@ -121,4 +124,4 @@ if __name__ == "__main__":
         # runtime.deploy(ceo)
         #
         # 2. In a separate long-lived worker process:
-        runtime.serve(ceo)
+        # runtime.serve(ceo)


### PR DESCRIPTION
The `runtime.run(...)` demo was commented out and `runtime.serve(ceo)` left uncommented, so the example printed a header and then blocked forever in the worker loop — it never demonstrated the hierarchy. Every sibling example keeps `serve()` commented under "Production pattern".

Uncommented the run, commented `serve()`, and reflowed the prompt off a single 200-char line.

Verified: COMPLETED in 25 tasks, both branches delegated — `ceo → engineering_lead`, `ceo → marketing_lead`.

Known gap, not addressed here: the leads answer directly rather than handing off to their specialists, so the third level (`backend_dev`, `content_writer`, …) the docstring advertises is still undemonstrated.