### PR TITLE
Pin mcp<2 in agent-e2e

### DIFF
--- a/.github/workflows/agent-e2e.yml
+++ b/.github/workflows/agent-e2e.yml
@@ -63,12 +63,26 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e '.[agents]'
-          pip install pytest pytest-asyncio pytest-xdist pytest-rerunfailures mcp-testkit
+          # mcp 2.0 dropped mcp.server.fastmcp, which mcp-testkit's server and
+          # tool modules still import — hold the resolver on the 1.x line until
+          # the testkit ships a 2.x-compatible release.
+          pip install pytest pytest-asyncio pytest-xdist pytest-rerunfailures mcp-testkit 'mcp<2'
 
       - name: Start mcp-testkit
         run: |
           mcp-testkit --transport http --port 3001 &
-          sleep 2
+          # Probe the port instead of a blind sleep — a testkit that dies on
+          # import used to leave this step green and surface only as downstream
+          # skips. curl exits non-zero while the port is refusing connections
+          # (a bare GET on a live /mcp answers 406, which counts as up).
+          for i in $(seq 1 15); do
+            if curl -s -o /dev/null http://localhost:3001/mcp; then
+              echo "mcp-testkit ready after ~${i}s"; exit 0
+            fi
+            sleep 1
+          done
+          echo "::error::mcp-testkit failed to start on port 3001"
+          exit 1
 
       - name: Start server
         run: |


### PR DESCRIPTION
mcp 2.0.0 removed `mcp.server.fastmcp`, which mcp-testkit still imports — the testkit died on import and `test_suite4_mcp_tools.py` failed collection. `mcp` was unpinned (transitive via claude-code-sdk).

Also probe the port instead of `sleep 2`, so a dead testkit fails its own step.

https://github.com/conductor-oss/python-sdk/actions/runs/31633373975/job/94237499406?pr=471

```
/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/site-packages/mcp_test_server/tools/echo_tools.py:5: in <module>
    from mcp.server.fastmcp.exceptions import ToolError
E   ModuleNotFoundError: No module named 'mcp.server.fastmcp'
- generated xml file: /home/runner/work/python-sdk/python-sdk/results/junit-e2e.xml -
=========================== short test summary info ============================
ERROR e2e/test_suite4_mcp_tools.py - ImportError while importing test module '/home/runner/work/python-sdk/python-sdk/e2e/test_suite4_mcp_tools.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.12.13/x64/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
e2e/test_suite4_mcp_tools.py:52: in <module>
    EXPECTED_TOOL_NAMES = _expected_tools_from_source()
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```