### PR TITLE
Fix sub_results iteration in the skills examples

### DIFF
--- a/examples/agents/30_skills_dg_review.py
+++ b/examples/agents/30_skills_dg_review.py
@@ -70,11 +70,12 @@ def run_standalone():
         print(f"Status: {result.status}")
         print(f"Tokens: {result.token_usage}")
 
-        # Sub-agent results are individually visible
+        # Sub-agent results are individually visible: a dict keyed by agent
+        # name — see AgentResult.sub_results.
         if result.sub_results:
-            print(f"\nSub-agent executions:")
-            for sub in result.sub_results:
-                print(f"  - {sub.agent_name}: {sub.status} ({sub.token_usage})")
+            print(f"\nSub-agent outputs:")
+            for agent_name, agent_output in result.sub_results.items():
+                print(f"  - {agent_name}: {str(agent_output)[:120]}")
 
 
 # ── Example 2: Compose with regular agent in pipeline ──────────────

--- a/examples/agents/32_skills_multi_agent.py
+++ b/examples/agents/32_skills_multi_agent.py
@@ -151,10 +151,11 @@ def example_pipeline():
         print(f"Execution ID: {result.execution_id}")
         print(f"Status:      {result.status}")
         print(f"Tokens:      {result.token_usage}")
+        # sub_results is a dict keyed by agent name — see AgentResult.sub_results.
         if result.sub_results:
-            print("\nSub-agent executions:")
-            for sub in result.sub_results:
-                print(f"  - {getattr(sub, "execution_id", "?")}: {sub.status}")
+            print("\nSub-agent outputs:")
+            for agent_name, agent_output in result.sub_results.items():
+                print(f"  - {agent_name}: {str(agent_output)[:120]}")
         result.print_result()
 
 
@@ -213,10 +214,11 @@ def example_parallel():
         print(f"Execution ID: {result.execution_id}")
         print(f"Status:      {result.status}")
         print(f"Tokens:      {result.token_usage}")
+        # sub_results is a dict keyed by agent name — see AgentResult.sub_results.
         if result.sub_results:
-            print("\nParallel sub-agent executions:")
-            for sub in result.sub_results:
-                print(f"  - {getattr(sub, "execution_id", "?")}: {sub.status}")
+            print("\nParallel sub-agent outputs:")
+            for agent_name, agent_output in result.sub_results.items():
+                print(f"  - {agent_name}: {str(agent_output)[:120]}")
         result.print_result()
 
 


### PR DESCRIPTION
`sub_results` is a dict keyed by agent name rather than object list, so iterating it yields strings. `32_skills_multi_agent.py parallel` died on the print — PARALLEL is the strategy that actually populates it:

```
AttributeError: 'str' object has no attribute 'status'
```

[src/conductor/ai/agents/result.py#L124](https://github.com/conductor-oss/python-sdk/blob/42aa983c35e14e2be0f2649b9ca87d90ae46189d/src/conductor/ai/agents/result.py#L124)

```
    finish_reason: Optional[FinishReason] = None
    error: Optional[str] = None
    events: List["AgentEvent"] = field(default_factory=list)
    sub_results: Dict[str, Any] = field(default_factory=dict).      <---HERE
```

The other two call sites have the same bug, and survived only because their `sub_results` was empty.

Verified against a 3.32.0-rc18 server: all 8 modes across both examples complete, and `parallel` prints all three sub-agent outputs.