### PR TITLE
CCOR-13193 - adding test run against oss server in ci

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      oss_conductor_version:
+        description: 'OSS Conductor image tag (falls back to E2E_TEST_OSS_CONDUCTOR_VERSION org var)'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -133,3 +138,65 @@ jobs:
           bash scripts/run_integration_tests.sh --bucket=${{ matrix.bucket }}
           -s --log-cli-level=INFO
           --log-cli-format='%(asctime)s %(levelname)s %(name)s: %(message)s'
+
+  # Integration tests (OSS): spins up Conductor OSS + Postgres via
+  # scripts/docker-compose-oss.yaml and runs the integration suite
+  # unauthenticated, with Orkes-only tests gated out via
+  # CONDUCTOR_SERVER_TYPE=oss (see the individual test files for the
+  # empirically-confirmed gaps). The same stack can be run locally with
+  # scripts/run-integration-oss.sh.
+  integration-tests-oss:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        bucket: [test-all, long-sync, long-async, core]
+    name: integration-test-oss (${{ matrix.bucket }})
+    env:
+      CONDUCTOR_SERVER_URL: http://localhost:8080/api
+      CONDUCTOR_SERVER_TYPE: oss
+      # See the comment on CONDUCTOR_HTTP2_ENABLED in the integration-test job
+      # above; kept consistent here even though the local OSS stack doesn't
+      # have the same proxy/LB in front of it.
+      CONDUCTOR_HTTP2_ENABLED: "false"
+      OSS_CONDUCTOR_VERSION: ${{ inputs.oss_conductor_version || vars.E2E_TEST_OSS_CONDUCTOR_VERSION }}
+    steps:
+      - name: Verify OSS Conductor version is set
+        run: |
+          if [ -z "$OSS_CONDUCTOR_VERSION" ]; then
+            echo "::error::No Conductor OSS image tag resolved. Set the E2E_TEST_OSS_CONDUCTOR_VERSION organization variable (and ensure its repository access policy includes this repo), or pass the oss_conductor_version input via workflow_dispatch."
+            exit 1
+          fi
+          echo "Using conductoross/conductor:$OSS_CONDUCTOR_VERSION"
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+          pip install pytest
+
+      - name: Start Conductor OSS stack
+        run: docker compose -f scripts/docker-compose-oss.yaml up -d
+
+      - name: Wait for Conductor to be healthy
+        run: timeout 120 bash -c 'until curl -sf http://localhost:8080/health; do sleep 5; done'
+
+      - name: Run integration tests (OSS)
+        run: >-
+          bash scripts/run_integration_tests.sh --bucket=${{ matrix.bucket }}
+          -s --log-cli-level=INFO
+          --log-cli-format='%(asctime)s %(levelname)s %(name)s: %(message)s'
+
+      - name: Dump Conductor logs
+        if: failure()
+        run: docker compose -f scripts/docker-compose-oss.yaml logs conductor-server

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -146,17 +146,10 @@ jobs:
   # empirically-confirmed gaps). The same stack can be run locally with
   # scripts/run-integration-oss.sh.
   #
-  # Unlike the authenticated integration-test job above (which matrix-splits
-  # into 4 parallel buckets to spread load against the shared dev server),
-  # this runs the whole suite as a single --bucket=all job: the local OSS
-  # stack is dedicated to this one run, so there's no shared-server
-  # contention to justify paying for 4x the Docker-stack startup cost.
-  # --bucket=all also means the "server doesn't reliably fire a task timeout
-  # on a CI-bounded timeline" carve-out (server_timeout_unreliable, see
-  # scripts/run_integration_tests.sh) is skipped -- confirmed empirically
-  # that a local, non-shared OSS instance times those tasks out reliably, so
-  # the carve-out doesn't apply here. Confirmed empirically end-to-end: 20
-  # passed, 70 skipped, 0 failed in ~3m53s.
+  # Unlike the authenticated integration-test job above, this runs the whole
+  # suite in one job (--bucket=all) instead of matrix-splitting it: the full
+  # OSS run finishes in under 5 minutes, so splitting it would just cause
+  # extra runner usage for no performance benefit.
   integration-tests-oss:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -145,14 +145,21 @@ jobs:
   # CONDUCTOR_SERVER_TYPE=oss (see the individual test files for the
   # empirically-confirmed gaps). The same stack can be run locally with
   # scripts/run-integration-oss.sh.
+  #
+  # Unlike the authenticated integration-test job above (which matrix-splits
+  # into 4 parallel buckets to spread load against the shared dev server),
+  # this runs the whole suite as a single --bucket=all job: the local OSS
+  # stack is dedicated to this one run, so there's no shared-server
+  # contention to justify paying for 4x the Docker-stack startup cost.
+  # --bucket=all also means the "server doesn't reliably fire a task timeout
+  # on a CI-bounded timeline" carve-out (server_timeout_unreliable, see
+  # scripts/run_integration_tests.sh) is skipped -- confirmed empirically
+  # that a local, non-shared OSS instance times those tasks out reliably, so
+  # the carve-out doesn't apply here. Confirmed empirically end-to-end: 20
+  # passed, 70 skipped, 0 failed in ~3m53s.
   integration-tests-oss:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        bucket: [test-all, long-sync, long-async, core]
-    name: integration-test-oss (${{ matrix.bucket }})
     env:
       CONDUCTOR_SERVER_URL: http://localhost:8080/api
       CONDUCTOR_SERVER_TYPE: oss
@@ -193,7 +200,7 @@ jobs:
 
       - name: Run integration tests (OSS)
         run: >-
-          bash scripts/run_integration_tests.sh --bucket=${{ matrix.bucket }}
+          bash scripts/run_integration_tests.sh --bucket=all
           -s --log-cli-level=INFO
           --log-cli-format='%(asctime)s %(levelname)s %(name)s: %(message)s'
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -189,7 +189,7 @@ jobs:
         run: docker compose -f scripts/docker-compose-oss.yaml up -d
 
       - name: Wait for Conductor to be healthy
-        run: timeout 120 bash -c 'until curl -sf http://localhost:8080/health; do sleep 5; done'
+        run: timeout 180 bash -c 'until curl -sf http://localhost:8080/health; do sleep 5; done'
 
       - name: Run integration tests (OSS)
         run: >-

--- a/scripts/docker-compose-oss.yaml
+++ b/scripts/docker-compose-oss.yaml
@@ -36,6 +36,6 @@ services:
       timeout: 5s
       retries: 12
   httpbin:
-    image: ghcr.io/conductor-oss/httpbin:latest
+    image: ghcr.io/conductor-oss/httpbin:v1.0.1
     expose:
       - "8081"

--- a/scripts/docker-compose-oss.yaml
+++ b/scripts/docker-compose-oss.yaml
@@ -1,0 +1,41 @@
+# Conductor OSS stack used to run the SDK integration tests against open-source
+# Conductor. Shared by scripts/run-integration-oss.sh and the
+# integration-tests-oss job in .github/workflows/pull_request.yml.
+#
+# The Conductor server reaches httpbin over the compose network at
+# http://httpbin:8081 (see e.g. tests/integration/client/orkes/test_orkes_service_registry_client.py
+# and the complex_wf_signal_test*.json fixtures).
+#
+# OSS_CONDUCTOR_VERSION defaults to `latest` for local runs; CI pins it via the
+# E2E_TEST_OSS_CONDUCTOR_VERSION org variable (or a workflow_dispatch input).
+services:
+  conductor-server:
+    image: conductoross/conductor:${OSS_CONDUCTOR_VERSION:-latest}
+    environment:
+      - CONFIG_PROP=config-postgres.properties
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-I", "-XGET", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 10s
+      retries: 20
+    links:
+      - conductor-postgres:postgresdb
+    depends_on:
+      conductor-postgres:
+        condition: service_healthy
+  conductor-postgres:
+    image: postgres:16
+    environment:
+      - POSTGRES_USER=conductor
+      - POSTGRES_PASSWORD=conductor
+    healthcheck:
+      test: timeout 5 bash -c 'cat < /dev/null > /dev/tcp/localhost/5432'
+      interval: 5s
+      timeout: 5s
+      retries: 12
+  httpbin:
+    image: ghcr.io/orkes-io/test-utils/httpbin:latest
+    expose:
+      - "8081"

--- a/scripts/docker-compose-oss.yaml
+++ b/scripts/docker-compose-oss.yaml
@@ -36,6 +36,6 @@ services:
       timeout: 5s
       retries: 12
   httpbin:
-    image: ghcr.io/orkes-io/test-utils/httpbin:latest
+    image: ghcr.io/conductor-oss/httpbin:latest
     expose:
       - "8081"

--- a/scripts/run-integration-oss.sh
+++ b/scripts/run-integration-oss.sh
@@ -3,11 +3,14 @@
 # Spin up a local Conductor OSS stack and run the SDK integration suite
 # against it, mirroring the `integration-tests-oss` job in
 # .github/workflows/pull_request.yml. Orkes-Enterprise-only tests/classes/
-# modules (Authorization, Secrets, Schema, Service Registry, Signal API,
+# modules (Authorization, Secrets, Schema, Service Registry,
 # metadata/scheduler tags) check `os.environ.get('CONDUCTOR_SERVER_TYPE')`
 # directly and skip themselves when it's "oss" (confirmed empirically not
 # implemented by plain OSS Conductor -- see the individual test files for
-# details on each gap).
+# details on each gap). The Signal API tests run on OSS too, using a
+# WAIT-task-based fixture variant instead of the YIELD-based one used against
+# Orkes Enterprise -- see _signal_test_workflow_names() in
+# tests/integration/workflow/test_workflow_execution.py.
 #
 # The stack (Conductor OSS + Postgres + httpbin) is defined in
 # scripts/docker-compose-oss.yaml and is torn down automatically on exit.

--- a/scripts/run-integration-oss.sh
+++ b/scripts/run-integration-oss.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 #
 # Spin up a local Conductor OSS stack and run the SDK integration suite
-# against it, mirroring the `integration-tests-oss` job in
-# .github/workflows/pull_request.yml. Orkes-Enterprise-only tests/classes/
+# against it. To reproduce the `integration-tests-oss` job in
+# .github/workflows/pull_request.yml you need `-- --bucket=all`: that job runs
+# the full suite, whereas this script defaults to the faster `core` bucket,
+# which excludes tests/integration/test_workflow_client_intg.py -- the only
+# entry point to the workflow-execution and Signal API scenarios.
+#
+# Orkes-Enterprise-only tests/classes/
 # modules (Authorization, Secrets, Schema, Service Registry,
 # metadata/scheduler tags) check `os.environ.get('CONDUCTOR_SERVER_TYPE')`
 # directly and skip themselves when it's "oss" (confirmed empirically not
@@ -18,21 +23,26 @@
 # Usage:
 #   scripts/run-integration-oss.sh [--keep-up] [--version <tag>] [-- pytest args]
 # Examples:
-#   scripts/run-integration-oss.sh                        # run scripts/run_integration_tests.sh --bucket=core against `latest`
+#   scripts/run-integration-oss.sh -- --bucket=all        # what CI runs: the full suite
+#   scripts/run-integration-oss.sh                        # faster: --bucket=core against `latest`
 #   scripts/run-integration-oss.sh --version 3.32.0-rc18
-#   scripts/run-integration-oss.sh --keep-up
-#   scripts/run-integration-oss.sh -- --bucket=all
+#   scripts/run-integration-oss.sh --keep-up              # leave the stack up afterwards
 set -euo pipefail
 
 KEEP_UP=0
+UP_ONLY=0
 extra=()
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --keep-up) KEEP_UP=1; shift ;;
+    # Bring the stack up and stop there, for pointing repeated test runs at it
+    # by hand. Implies --keep-up: tearing down the stack we just started would
+    # defeat the purpose.
+    --up-only) UP_ONLY=1; KEEP_UP=1; shift ;;
     --version) OSS_CONDUCTOR_VERSION="${2:?--version needs a tag}"; shift 2 ;;
     -h|--help)
-      echo "Usage: $0 [--keep-up] [--version <tag>] [-- pytest args]"
+      echo "Usage: $0 [--up-only] [--keep-up] [--version <tag>] [-- pytest args]"
       exit 0
       ;;
     --) shift; extra=("$@"); break ;;
@@ -78,5 +88,13 @@ echo "Conductor is up."
 
 export CONDUCTOR_SERVER_URL="http://localhost:8080/api"
 export CONDUCTOR_SERVER_TYPE="oss"
+
+if [[ "${UP_ONLY}" == "1" ]]; then
+  echo "--up-only set: stack is up, not running the suite. Point runs at it with:"
+  echo "  export CONDUCTOR_SERVER_URL=\"${CONDUCTOR_SERVER_URL}\""
+  echo "  export CONDUCTOR_SERVER_TYPE=\"${CONDUCTOR_SERVER_TYPE}\""
+  echo "  bash scripts/run_integration_tests.sh --bucket=all"
+  exit 0
+fi
 
 bash scripts/run_integration_tests.sh ${extra[@]+"${extra[@]}"}

--- a/scripts/run-integration-oss.sh
+++ b/scripts/run-integration-oss.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Spin up a local Conductor OSS stack and run the SDK integration suite
+# against it, mirroring the `integration-tests-oss` job in
+# .github/workflows/pull_request.yml. Orkes-Enterprise-only tests/classes/
+# modules (Authorization, Secrets, Schema, Service Registry, Signal API,
+# metadata/scheduler tags) check `os.environ.get('CONDUCTOR_SERVER_TYPE')`
+# directly and skip themselves when it's "oss" (confirmed empirically not
+# implemented by plain OSS Conductor -- see the individual test files for
+# details on each gap).
+#
+# The stack (Conductor OSS + Postgres + httpbin) is defined in
+# scripts/docker-compose-oss.yaml and is torn down automatically on exit.
+#
+# Usage:
+#   scripts/run-integration-oss.sh [--keep-up] [--version <tag>] [-- pytest args]
+# Examples:
+#   scripts/run-integration-oss.sh                        # run scripts/run_integration_tests.sh --bucket=core against `latest`
+#   scripts/run-integration-oss.sh --version 3.32.0-rc18
+#   scripts/run-integration-oss.sh --keep-up
+#   scripts/run-integration-oss.sh -- --bucket=all
+set -euo pipefail
+
+KEEP_UP=0
+extra=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --keep-up) KEEP_UP=1; shift ;;
+    --version) OSS_CONDUCTOR_VERSION="${2:?--version needs a tag}"; shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 [--keep-up] [--version <tag>] [-- pytest args]"
+      exit 0
+      ;;
+    --) shift; extra=("$@"); break ;;
+    *) echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+export OSS_CONDUCTOR_VERSION="${OSS_CONDUCTOR_VERSION:-latest}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+COMPOSE_FILE="${SCRIPT_DIR}/docker-compose-oss.yaml"
+cd "${REPO_ROOT}"
+
+compose() { docker compose -f "${COMPOSE_FILE}" "$@"; }
+
+cleanup() {
+  if [[ "${KEEP_UP}" == "1" ]]; then
+    echo "--keep-up set: leaving the OSS stack running. Tear down with:"
+    echo "  docker compose -f ${COMPOSE_FILE} down -v"
+    return
+  fi
+  echo "Tearing down Conductor OSS stack..."
+  compose down -v || true
+}
+trap cleanup EXIT
+
+echo "Starting Conductor OSS stack (conductoross/conductor:${OSS_CONDUCTOR_VERSION})..."
+compose up -d
+
+echo "Waiting for Conductor to be healthy..."
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
+deadline=$(( SECONDS + HEALTH_TIMEOUT ))
+until curl -sf http://localhost:8080/health >/dev/null 2>&1; do
+  if (( SECONDS >= deadline )); then
+    echo "Error: Conductor did not become healthy within ${HEALTH_TIMEOUT}s." >&2
+    compose logs conductor-server || true
+    exit 1
+  fi
+  sleep 5
+done
+echo "Conductor is up."
+
+export CONDUCTOR_SERVER_URL="http://localhost:8080/api"
+export CONDUCTOR_SERVER_TYPE="oss"
+
+bash scripts/run_integration_tests.sh ${extra[@]+"${extra[@]}"}

--- a/scripts/run-integration-oss.sh
+++ b/scripts/run-integration-oss.sh
@@ -62,6 +62,11 @@ cd "${REPO_ROOT}"
 compose() { docker compose -f "${COMPOSE_FILE}" "$@"; }
 
 cleanup() {
+  local status=$?
+  if [[ "${status}" -ne 0 ]]; then
+    echo "Dumping conductor-server logs (exit ${status})..." >&2
+    compose logs conductor-server || true
+  fi
   if [[ "${KEEP_UP}" == "1" ]]; then
     echo "--keep-up set: leaving the OSS stack running. Tear down with:"
     echo "  docker compose -f ${COMPOSE_FILE} down -v"
@@ -90,7 +95,6 @@ deadline=$(( SECONDS + HEALTH_TIMEOUT ))
 until curl -sf http://localhost:8080/health >/dev/null 2>&1; do
   if (( SECONDS >= deadline )); then
     echo "Error: Conductor did not become healthy within ${HEALTH_TIMEOUT}s." >&2
-    compose logs conductor-server || true
     exit 1
   fi
   sleep 5

--- a/scripts/run-integration-oss.sh
+++ b/scripts/run-integration-oss.sh
@@ -7,26 +7,28 @@
 # which excludes tests/integration/test_workflow_client_intg.py -- the only
 # entry point to the workflow-execution and Signal API scenarios.
 #
-# Orkes-Enterprise-only tests/classes/
-# modules (Authorization, Secrets, Schema, Service Registry,
-# metadata/scheduler tags) check `os.environ.get('CONDUCTOR_SERVER_TYPE')`
-# directly and skip themselves when it's "oss" (confirmed empirically not
-# implemented by plain OSS Conductor -- see the individual test files for
-# details on each gap). The Signal API tests run on OSS too, using a
-# WAIT-task-based fixture variant instead of the YIELD-based one used against
-# Orkes Enterprise -- see _signal_test_workflow_names() in
+# Orkes-Enterprise-only tests, classes, and modules (Authorization, Secrets,
+# Schema, Service Registry, metadata/scheduler tags) gate themselves on
+# is_oss() in tests/integration/conftest.py, which reads the
+# CONDUCTOR_SERVER_TYPE this script exports below; its docstring carries the
+# authoritative list of gated surface (confirmed empirically not implemented by
+# plain OSS Conductor -- see the individual test files for details on each
+# gap). The Signal API tests run on OSS too, using a WAIT-task-based fixture
+# variant instead of the YIELD-based one used against Orkes Enterprise -- see
+# _signal_test_workflow_names() in
 # tests/integration/workflow/test_workflow_execution.py.
 #
 # The stack (Conductor OSS + Postgres + httpbin) is defined in
 # scripts/docker-compose-oss.yaml and is torn down automatically on exit.
 #
 # Usage:
-#   scripts/run-integration-oss.sh [--keep-up] [--version <tag>] [-- pytest args]
+#   scripts/run-integration-oss.sh [--up-only] [--keep-up] [--version <tag>] [-- pytest args]
 # Examples:
 #   scripts/run-integration-oss.sh -- --bucket=all        # what CI runs: the full suite
 #   scripts/run-integration-oss.sh                        # faster: --bucket=core against `latest`
 #   scripts/run-integration-oss.sh --version 3.32.0-rc18
 #   scripts/run-integration-oss.sh --keep-up              # leave the stack up afterwards
+#   scripts/run-integration-oss.sh --up-only              # start the stack, skip the suite
 set -euo pipefail
 
 KEEP_UP=0
@@ -70,7 +72,16 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "Starting Conductor OSS stack (conductoross/conductor:${OSS_CONDUCTOR_VERSION})..."
+echo "Using conductoross/conductor:${OSS_CONDUCTOR_VERSION}"
+
+# `docker compose up` only pulls an image when it is missing locally, so a
+# previously-cached `latest` (or any other mutable tag) would silently be
+# reused instead of getting the current version. Pull unconditionally so the
+# stack always reflects the tag we just printed.
+echo "Pulling conductoross/conductor:${OSS_CONDUCTOR_VERSION} to ensure it's current..."
+compose pull conductor-server
+
+echo "Starting Conductor OSS stack..."
 compose up -d
 
 echo "Waiting for Conductor to be healthy..."

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -12,23 +12,17 @@ End-to-end integration tests that run against a **real Conductor server**.
 
 **Option A: Local Conductor OSS (Docker Compose, recommended)**
 ```bash
-scripts/run-integration-oss.sh
+scripts/run-integration-oss.sh --up-only
 ```
-This starts a Postgres-backed Conductor OSS stack (`scripts/docker-compose-oss.yaml`),
-waits for it to become healthy, and runs the suite against it with
-`CONDUCTOR_SERVER_TYPE=oss` set. Orkes-Enterprise-only tests/classes/modules
-(Authorization, Secrets, Schema, Service Registry, metadata/scheduler tags)
-check that env var directly and skip themselves -- see the individual test
-files for the specific gaps confirmed empirically against plain OSS
-Conductor. The Signal API tests run on OSS too, using a WAIT-task-based
-fixture (`complex_wf_signal_test_oss` and friends) instead of the
-Orkes-Enterprise-only YIELD-based one -- see `_signal_test_workflow_names()`
-in `tests/integration/workflow/test_workflow_execution.py`.
+This starts a Postgres-backed Conductor OSS stack
+(`scripts/docker-compose-oss.yaml`), waits for it to become healthy, and stops
+there, leaving it running for you to point test runs at. Tear it down with
+`docker compose -f scripts/docker-compose-oss.yaml down -v`. Pass
+`--version <tag>` to pin a specific `conductoross/conductor` image.
 
-Pass `--version <tag>` to pin a specific
-`conductoross/conductor` image, or `--keep-up` to leave the stack running
-after the suite finishes; anything after `--` is forwarded to
-`scripts/run_integration_tests.sh` (e.g. `-- --bucket=all`).
+Without `--up-only` the same script also runs the suite and then tears the
+stack down — see [Against local Conductor OSS](#against-local-conductor-oss)
+below.
 
 **Option B: Orkes Cloud**
 ```bash
@@ -44,6 +38,12 @@ export CONDUCTOR_AUTH_SECRET="your-key-secret"
 # Required
 export CONDUCTOR_SERVER_URL="http://localhost:8080/api"
 
+# Required when the server is plain OSS Conductor (Option A). Orkes-only
+# tests check this and skip themselves; without it they fail instead.
+# run-integration-oss.sh exports it for the run it drives, but a stack left
+# up with --up-only or --keep-up needs it set in your own shell.
+export CONDUCTOR_SERVER_TYPE="oss"
+
 # Optional (for Orkes Cloud)
 export CONDUCTOR_AUTH_KEY="your-key"
 export CONDUCTOR_AUTH_SECRET="your-secret"
@@ -55,8 +55,11 @@ export CONDUCTOR_AUTH_SECRET="your-secret"
 
 ### Run the CI suite locally (recommended)
 
-Use the helper script to run exactly what CI runs (the `integration-test` job in
-[`.github/workflows/pull_request.yml`](../../.github/workflows/pull_request.yml)).
+Use the helper script to run exactly what the `integration-test` job in
+[`.github/workflows/pull_request.yml`](../../.github/workflows/pull_request.yml)
+runs against the authenticated Orkes server. (For the second CI job, which runs
+against plain OSS Conductor, see
+[Against local Conductor OSS](#against-local-conductor-oss) below.)
 It excludes the AI/agentic tests (which need a dedicated AI-enabled server) and
 the slow performance test, so you don't have to remember the `--ignore` flags:
 
@@ -96,6 +99,39 @@ Any extra arguments pass straight through to pytest, which is handy for
 targeting a subset of tests or getting more detail on failures. See additional
 options and examples in the comments at the top of
 [`scripts/run_integration_tests.sh`](../../scripts/run_integration_tests.sh).
+
+### Against local Conductor OSS
+
+`scripts/run-integration-oss.sh` brings up the OSS stack, runs the suite against
+it with `CONDUCTOR_SERVER_TYPE=oss` set, and tears the stack down on exit:
+
+```bash
+# What the integration-tests-oss CI job runs — the full suite:
+scripts/run-integration-oss.sh -- --bucket=all
+
+# Faster loop: the `core` bucket only (the default if no bucket is given)
+scripts/run-integration-oss.sh
+```
+
+**The default is `--bucket=core`, which is not what CI runs.** `core` excludes
+`test_workflow_client_intg.py`, and that file is the only entry point to the
+workflow-execution and Signal API scenarios — so the default run exercises
+neither. Use `-- --bucket=all` to reproduce a CI failure.
+
+Anything after `--` is forwarded to `scripts/run_integration_tests.sh`, so the
+bucket table and pytest passthrough above apply here too. `--version <tag>`,
+`--keep-up` (leave the stack up afterwards) and `--up-only` (start the stack and
+skip the suite) are handled by the script itself and go *before* the `--`.
+
+On OSS, the Orkes-Enterprise-only tests, classes, and modules (Authorization,
+Secrets, Schema, Service Registry, metadata/scheduler tags) check
+`CONDUCTOR_SERVER_TYPE` and skip themselves — see the individual test files for
+the specific gap each one covers. The Signal API tests *do* run, using
+WAIT-task-based fixtures (`complex_wf_signal_test_oss` and friends) instead of
+the Orkes-only YIELD-based ones; see `_signal_test_workflow_names()` in
+[`workflow/test_workflow_execution.py`](workflow/test_workflow_execution.py).
+
+Expect a large number of skips: a full OSS run is roughly 20 passed / 70 skipped.
 
 ### Run All Integration Tests
 
@@ -422,8 +458,8 @@ curl http://localhost:8080/api/health
 # Check environment variable
 echo $CONDUCTOR_SERVER_URL
 
-# Start local server
-scripts/run-integration-oss.sh --keep-up
+# Start local server (stack only, no test run)
+scripts/run-integration-oss.sh --up-only
 ```
 
 ### Tests Timeout

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -123,9 +123,13 @@ bucket table and pytest passthrough above apply here too. `--version <tag>`,
 `--keep-up` (leave the stack up afterwards) and `--up-only` (start the stack and
 skip the suite) are handled by the script itself and go *before* the `--`.
 
+`--version <tag>` pins the image; without it the stack uses `latest`, which is
+mutable — the script re-pulls on every run so it never serves a stale cache.
+
 On OSS, the Orkes-Enterprise-only tests, classes, and modules (Authorization,
-Secrets, Schema, Service Registry, metadata/scheduler tags) check
-`CONDUCTOR_SERVER_TYPE` and skip themselves — see the individual test files for
+Secrets, Schema, Service Registry, metadata/scheduler tags) gate themselves on
+`is_oss()` in [`conftest.py`](conftest.py) (which reads
+`CONDUCTOR_SERVER_TYPE`) and skip themselves — see the individual test files for
 the specific gap each one covers. The Signal API tests *do* run, using
 WAIT-task-based fixtures (`complex_wf_signal_test_oss` and friends) instead of
 the Orkes-only YIELD-based ones; see `_signal_test_workflow_names()` in

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -10,10 +10,20 @@ End-to-end integration tests that run against a **real Conductor server**.
 
 ### 1. Conductor Server Running
 
-**Option A: Local Conductor (Docker)**
+**Option A: Local Conductor OSS (Docker Compose, recommended)**
 ```bash
-docker run --init -p 8080:8080 -p 5000:5000 conductoross/conductor-standalone:3.15.0
+scripts/run-integration-oss.sh
 ```
+This starts a Postgres-backed Conductor OSS stack (`scripts/docker-compose-oss.yaml`),
+waits for it to become healthy, and runs the suite against it with
+`CONDUCTOR_SERVER_TYPE=oss` set. Orkes-Enterprise-only tests/classes/modules
+(Authorization, Secrets, Schema, Service Registry, the Signal API, metadata/
+scheduler tags) check that env var directly and skip themselves -- see the
+individual test files for the specific gaps confirmed empirically against
+plain OSS Conductor. Pass `--version <tag>` to pin a specific
+`conductoross/conductor` image, or `--keep-up` to leave the stack running
+after the suite finishes; anything after `--` is forwarded to
+`scripts/run_integration_tests.sh` (e.g. `-- --bucket=all`).
 
 **Option B: Orkes Cloud**
 ```bash
@@ -408,7 +418,7 @@ curl http://localhost:8080/api/health
 echo $CONDUCTOR_SERVER_URL
 
 # Start local server
-docker run --init -p 8080:8080 -p 5000:5000 conductoross/conductor-standalone:3.15.0
+scripts/run-integration-oss.sh --keep-up
 ```
 
 ### Tests Timeout

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -17,10 +17,15 @@ scripts/run-integration-oss.sh
 This starts a Postgres-backed Conductor OSS stack (`scripts/docker-compose-oss.yaml`),
 waits for it to become healthy, and runs the suite against it with
 `CONDUCTOR_SERVER_TYPE=oss` set. Orkes-Enterprise-only tests/classes/modules
-(Authorization, Secrets, Schema, Service Registry, the Signal API, metadata/
-scheduler tags) check that env var directly and skip themselves -- see the
-individual test files for the specific gaps confirmed empirically against
-plain OSS Conductor. Pass `--version <tag>` to pin a specific
+(Authorization, Secrets, Schema, Service Registry, metadata/scheduler tags)
+check that env var directly and skip themselves -- see the individual test
+files for the specific gaps confirmed empirically against plain OSS
+Conductor. The Signal API tests run on OSS too, using a WAIT-task-based
+fixture (`complex_wf_signal_test_oss` and friends) instead of the
+Orkes-Enterprise-only YIELD-based one -- see `_signal_test_workflow_names()`
+in `tests/integration/workflow/test_workflow_execution.py`.
+
+Pass `--version <tag>` to pin a specific
 `conductoross/conductor` image, or `--keep-up` to leave the stack running
 after the suite finishes; anything after `--` is forwarded to
 `scripts/run_integration_tests.sh` (e.g. `-- --bucket=all`).

--- a/tests/integration/client/orkes/test_orkes_clients.py
+++ b/tests/integration/client/orkes/test_orkes_clients.py
@@ -1,5 +1,4 @@
 import json
-import os
 import time
 
 from shortuuid import uuid
@@ -27,6 +26,7 @@ from conductor.client.orkes_clients import OrkesClients
 from conductor.client.workflow.conductor_workflow import ConductorWorkflow
 from conductor.client.workflow.executor.workflow_executor import WorkflowExecutor
 from conductor.client.workflow.task.simple_task import SimpleTask
+from tests.integration.conftest import is_oss
 from tests.integration.retry_helpers import retry_scenario, wait_for_workflow_terminal
 
 SUFFIX = str(uuid())
@@ -141,7 +141,7 @@ class TestOrkesClients:
         # call 404s "No static resource api/secrets|applications|users|groups...".
         # Gate these Orkes-Enterprise-only lifecycles rather than letting them
         # fail against a local OSS stack.
-        if os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss':
+        if is_oss():
             return
 
         retry_scenario('test_secret_lifecycle', self.test_secret_lifecycle,
@@ -162,7 +162,7 @@ class TestOrkesClients:
         # that path 404s/500s as an unmapped route (DELETE even falls through
         # to the unrelated /metadata/workflow/{name}/{version} route, taking
         # "tags" as the version path segment).
-        if os.environ.get('CONDUCTOR_SERVER_TYPE') != 'oss':
+        if not is_oss():
             self.__test_workflow_tags()
         self.__test_unregister_workflow_definition()
 
@@ -189,7 +189,7 @@ class TestOrkesClients:
         # Metadata tagging (/metadata/task/{name}/tags) is not implemented by
         # plain OSS Conductor -- confirmed empirically (404 "No static
         # resource api/metadata/task/.../tags").
-        if os.environ.get('CONDUCTOR_SERVER_TYPE') != 'oss':
+        if not is_oss():
             self.__test_task_tags()
         self.__test_task_execution_lifecycle()
 
@@ -260,7 +260,7 @@ class TestOrkesClients:
         # Metadata tagging (/scheduler/schedules/{name}/tags) is not
         # implemented by plain OSS Conductor -- confirmed empirically (404
         # "No static resource api/scheduler/schedules/.../tags").
-        if os.environ.get('CONDUCTOR_SERVER_TYPE') != 'oss':
+        if not is_oss():
             tags = [
                 MetadataTag("sch_tag", "val"), MetadataTag("sch_tag_2", "val2")
             ]
@@ -639,7 +639,7 @@ class TestOrkesClients:
         # against OSS.
         self.workflow_client.delete_workflow(
             workflow_uuid,
-            archive_workflow=os.environ.get('CONDUCTOR_SERVER_TYPE') != 'oss'
+            archive_workflow=not is_oss()
         )
         _assert_not_found(
             lambda: self.workflow_client.get_workflow(workflow_uuid, False), workflow_uuid

--- a/tests/integration/client/orkes/test_orkes_clients.py
+++ b/tests/integration/client/orkes/test_orkes_clients.py
@@ -1,4 +1,5 @@
 import json
+import os
 import time
 
 from shortuuid import uuid
@@ -130,13 +131,22 @@ class TestOrkesClients:
                        workflowDef, workflow, deadline=deadline)
         retry_scenario('test_task_lifecycle', self.test_task_lifecycle,
                        deadline=deadline)
-        retry_scenario('test_secret_lifecycle', self.test_secret_lifecycle,
-                       deadline=deadline)
         retry_scenario('test_scheduler_lifecycle', self.test_scheduler_lifecycle,
                        workflowDef, deadline=deadline)
-        retry_scenario('test_application_lifecycle', self.test_application_lifecycle,
-                       deadline=deadline)
         retry_scenario('__test_unit_test_workflow', self.__test_unit_test_workflow,
+                       deadline=deadline)
+
+        # Secret and Authorization (application/user/group/permission) APIs are
+        # not implemented by plain OSS Conductor -- confirmed empirically: every
+        # call 404s "No static resource api/secrets|applications|users|groups...".
+        # Gate these Orkes-Enterprise-only lifecycles rather than letting them
+        # fail against a local OSS stack.
+        if os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss':
+            return
+
+        retry_scenario('test_secret_lifecycle', self.test_secret_lifecycle,
+                       deadline=deadline)
+        retry_scenario('test_application_lifecycle', self.test_application_lifecycle,
                        deadline=deadline)
         retry_scenario('test_user_group_permissions_lifecycle',
                        self.test_user_group_permissions_lifecycle, workflowDef,
@@ -147,7 +157,13 @@ class TestOrkesClients:
         self.__test_get_workflow_definition()
         self.__test_update_workflow_definition(workflow)
         self.__test_workflow_execution_lifecycle()
-        self.__test_workflow_tags()
+        # Metadata tagging (/metadata/workflow/{name}/tags) is not implemented
+        # by plain OSS Conductor -- confirmed empirically: every HTTP verb on
+        # that path 404s/500s as an unmapped route (DELETE even falls through
+        # to the unrelated /metadata/workflow/{name}/{version} route, taking
+        # "tags" as the version path segment).
+        if os.environ.get('CONDUCTOR_SERVER_TYPE') != 'oss':
+            self.__test_workflow_tags()
         self.__test_unregister_workflow_definition()
 
     def test_task_lifecycle(self):
@@ -170,7 +186,11 @@ class TestOrkesClients:
         assert fetchedTaskDef.description == taskDef.description
         assert len(fetchedTaskDef.input_keys) == 3
 
-        self.__test_task_tags()
+        # Metadata tagging (/metadata/task/{name}/tags) is not implemented by
+        # plain OSS Conductor -- confirmed empirically (404 "No static
+        # resource api/metadata/task/.../tags").
+        if os.environ.get('CONDUCTOR_SERVER_TYPE') != 'oss':
+            self.__test_task_tags()
         self.__test_task_execution_lifecycle()
 
         self.metadata_client.unregister_task_def(TASK_TYPE)
@@ -237,16 +257,20 @@ class TestOrkesClients:
         times = self.scheduler_client.get_next_few_schedule_execution_times("0 */5 * ? * *", limit=1)
         assert (len(times) == 1)
 
-        tags = [
-            MetadataTag("sch_tag", "val"), MetadataTag("sch_tag_2", "val2")
-        ]
-        self.scheduler_client.set_scheduler_tags(tags, SCHEDULE_NAME)
-        fetched_tags = self.scheduler_client.get_scheduler_tags(SCHEDULE_NAME)
-        assert len(fetched_tags) == 2
+        # Metadata tagging (/scheduler/schedules/{name}/tags) is not
+        # implemented by plain OSS Conductor -- confirmed empirically (404
+        # "No static resource api/scheduler/schedules/.../tags").
+        if os.environ.get('CONDUCTOR_SERVER_TYPE') != 'oss':
+            tags = [
+                MetadataTag("sch_tag", "val"), MetadataTag("sch_tag_2", "val2")
+            ]
+            self.scheduler_client.set_scheduler_tags(tags, SCHEDULE_NAME)
+            fetched_tags = self.scheduler_client.get_scheduler_tags(SCHEDULE_NAME)
+            assert len(fetched_tags) == 2
 
-        self.scheduler_client.delete_scheduler_tags(tags, SCHEDULE_NAME)
-        fetched_tags = self.scheduler_client.get_scheduler_tags(SCHEDULE_NAME)
-        assert len(fetched_tags) == 0
+            self.scheduler_client.delete_scheduler_tags(tags, SCHEDULE_NAME)
+            fetched_tags = self.scheduler_client.get_scheduler_tags(SCHEDULE_NAME)
+            assert len(fetched_tags) == 0
 
         self.scheduler_client.delete_schedule(SCHEDULE_NAME)
         _assert_not_found(
@@ -608,7 +632,15 @@ class TestOrkesClients:
         workflow = self.workflow_client.get_workflow(workflow_uuid, False)
         assert workflow.status == "RUNNING"
 
-        self.workflow_client.delete_workflow(workflow_uuid)
+        # archive_workflow=True (the default) requires a terminal-state workflow;
+        # this workflow is intentionally still RUNNING at this point (confirmed
+        # empirically: "Cannot archive workflow ... with status: RUNNING" on
+        # plain OSS Conductor), so skip archiving for this delete when running
+        # against OSS.
+        self.workflow_client.delete_workflow(
+            workflow_uuid,
+            archive_workflow=os.environ.get('CONDUCTOR_SERVER_TYPE') != 'oss'
+        )
         _assert_not_found(
             lambda: self.workflow_client.get_workflow(workflow_uuid, False), workflow_uuid
         )

--- a/tests/integration/client/orkes/test_orkes_service_registry_client.py
+++ b/tests/integration/client/orkes/test_orkes_service_registry_client.py
@@ -12,6 +12,7 @@ from conductor.client.http.models.service_method import ServiceMethod
 from conductor.client.http.models.proto_registry_entry import ProtoRegistryEntry
 from conductor.client.orkes.orkes_service_registry_client import OrkesServiceRegistryClient
 from conductor.client.http.rest import ApiException
+from tests.integration.conftest import is_oss
 from tests.integration.retry_helpers import (
     DEFAULT_OVERALL_DEADLINE_SECONDS,
     retry_scenario,
@@ -274,7 +275,7 @@ class TestOrkesServiceRegistryClient:
 
 
 @unittest.skipIf(
-    os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss',
+    is_oss(),
     "The Service Registry API (/service-registry) is not implemented by "
     "plain OSS Conductor -- confirmed empirically (404 'No static resource "
     "api/service-registry')."

--- a/tests/integration/client/orkes/test_orkes_service_registry_client.py
+++ b/tests/integration/client/orkes/test_orkes_service_registry_client.py
@@ -273,6 +273,12 @@ class TestOrkesServiceRegistryClient:
             return b'\x08\x96\x01\x12\x04\x08\x02\x10\x03'
 
 
+@unittest.skipIf(
+    os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss',
+    "The Service Registry API (/service-registry) is not implemented by "
+    "plain OSS Conductor -- confirmed empirically (404 'No static resource "
+    "api/service-registry')."
+)
 class TestOrkesServiceRegistryClientIntg(unittest.TestCase):
     """Integration test wrapper following your existing pattern"""
 

--- a/tests/integration/client/test_async.py
+++ b/tests/integration/client/test_async.py
@@ -2,14 +2,22 @@ from conductor.client.http.api.metadata_resource_api import MetadataResourceApi
 from conductor.client.http.api_client import ApiClient
 from conductor.client.http.models.task_def import TaskDef
 
-TASK_NAME = 'python_integration_test_task'
+# Owned by this test alone. It used to reuse 'python_integration_test_task',
+# which tests/integration/workflow/test_workflow_execution.py registers with
+# real timeouts and actually runs workflows against -- and since this file and
+# that one run as separate concurrent CI jobs against the same server, whichever
+# registered last won. This file only needs *some* task def to exist for the
+# async lookup below, so it registers its own instead of overwriting one another
+# suite depends on.
+TASK_NAME = 'async_metadata_probe_task'
 
 
 def test_async_method(api_client: ApiClient):
     metadata_client = MetadataResourceApi(api_client)
 
     # Ensure the task def exists so the async lookup has something to return,
-    # regardless of test ordering.
+    # regardless of test ordering. A bare TaskDef is fine: nothing executes this
+    # task, it only needs to be retrievable.
     metadata_client.register_task_def(body=[TaskDef(name=TASK_NAME)])
 
     thread = metadata_client.get_task_def(

--- a/tests/integration/client/test_async.py
+++ b/tests/integration/client/test_async.py
@@ -9,6 +9,13 @@ from conductor.client.http.models.task_def import TaskDef
 # registered last won. This file only needs *some* task def to exist for the
 # async lookup below, so it registers its own instead of overwriting one another
 # suite depends on.
+#
+# Fixed name on purpose, and no teardown: POST /metadata/taskdefs upserts and
+# this def's content never varies, so it costs exactly one task-def slot however
+# many times the suite runs. A per-run name (as in leaked_task_defs.TEST_PREFIXES)
+# would register a new def every run -- the leak that reached the 402 cap -- and
+# deleting a shared fixed name is worse still: it can race a concurrent run
+# between its register and its lookup.
 TASK_NAME = 'async_metadata_probe_task'
 
 
@@ -20,16 +27,7 @@ def test_async_method(api_client: ApiClient):
     # task, it only needs to be retrievable.
     metadata_client.register_task_def(body=[TaskDef(name=TASK_NAME)])
 
-    try:
-        thread = metadata_client.get_task_def(
-            async_req=True, tasktype=TASK_NAME)
-        thread.wait()
-        assert thread.get() is not None
-    finally:
-        # Don't leave this def behind on a long-lived shared server: the name is
-        # fixed rather than run-suffixed, so it isn't matched by
-        # leaked_task_defs.TEST_PREFIXES and the reclaim pass would never
-        # collect it. cleanup_metadata swallows its own failures, so this can
-        # never turn a passing test red.
-        from tests.integration.conftest import cleanup_metadata
-        cleanup_metadata(api_client.configuration, task_defs=(TASK_NAME,))
+    thread = metadata_client.get_task_def(
+        async_req=True, tasktype=TASK_NAME)
+    thread.wait()
+    assert thread.get() is not None

--- a/tests/integration/client/test_async.py
+++ b/tests/integration/client/test_async.py
@@ -20,7 +20,16 @@ def test_async_method(api_client: ApiClient):
     # task, it only needs to be retrievable.
     metadata_client.register_task_def(body=[TaskDef(name=TASK_NAME)])
 
-    thread = metadata_client.get_task_def(
-        async_req=True, tasktype=TASK_NAME)
-    thread.wait()
-    assert thread.get() is not None
+    try:
+        thread = metadata_client.get_task_def(
+            async_req=True, tasktype=TASK_NAME)
+        thread.wait()
+        assert thread.get() is not None
+    finally:
+        # Don't leave this def behind on a long-lived shared server: the name is
+        # fixed rather than run-suffixed, so it isn't matched by
+        # leaked_task_defs.TEST_PREFIXES and the reclaim pass would never
+        # collect it. cleanup_metadata swallows its own failures, so this can
+        # never turn a passing test red.
+        from tests.integration.conftest import cleanup_metadata
+        cleanup_metadata(api_client.configuration, task_defs=(TASK_NAME,))

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@ or connection errors.
 """
 
 import logging
+import os
 import unittest
 
 import pytest
@@ -16,6 +17,22 @@ from conductor.client.http.api_client import ApiClient
 from conductor.client.workflow.executor.workflow_executor import WorkflowExecutor
 
 logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Server flavour
+# ---------------------------------------------------------------------------
+
+def is_oss():
+    """True when the suite is pointed at plain OSS Conductor rather than Orkes.
+
+    Set by scripts/run-integration-oss.sh and the integration-tests-oss CI job.
+    Gates the Orkes-Enterprise-only surface (Authorization, Secrets, Schema,
+    Service Registry, metadata/scheduler tags) and the handful of places where
+    OSS needs a different code path -- see the individual call sites.
+    """
+    return os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss'
+
 
 # ---------------------------------------------------------------------------
 # Connectivity check (cached at module level, runs once per session)

--- a/tests/integration/metadata/test_schema_service.py
+++ b/tests/integration/metadata/test_schema_service.py
@@ -1,11 +1,11 @@
 import json
 import logging
-import os
 import unittest
 from conductor.client.configuration.configuration import Configuration
 from conductor.client.http.api.schema_resource_api import SchemaResourceApi
 from conductor.client.http.models.schema_def import SchemaDef, SchemaType
 from conductor.client.orkes.orkes_schema_client import OrkesSchemaClient
+from tests.integration.conftest import is_oss
 from tests.integration.retry_helpers import retry_on_transient, retry_on_status
 
 SCHEMA_NAME = 'ut_schema'
@@ -24,7 +24,7 @@ schema = {
 
 
 @unittest.skipIf(
-    os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss',
+    is_oss(),
     "The Schema API (/schema) is not implemented by plain OSS Conductor "
     "-- confirmed empirically (404 'No static resource api/schema')."
 )

--- a/tests/integration/metadata/test_schema_service.py
+++ b/tests/integration/metadata/test_schema_service.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import os
 import unittest
 from conductor.client.configuration.configuration import Configuration
 from conductor.client.http.api.schema_resource_api import SchemaResourceApi
@@ -20,6 +21,13 @@ schema = {
     }
   }
 }
+
+
+@unittest.skipIf(
+    os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss',
+    "The Schema API (/schema) is not implemented by plain OSS Conductor "
+    "-- confirmed empirically (404 'No static resource api/schema')."
+)
 class TestOrkesSchemaClient(unittest.TestCase):
 
     @classmethod

--- a/tests/integration/metadata/test_task_metadata_service.py
+++ b/tests/integration/metadata/test_task_metadata_service.py
@@ -1,12 +1,8 @@
-import json
 import logging
 import unittest
 from conductor.client.configuration.configuration import Configuration
-from conductor.client.http.api.schema_resource_api import SchemaResourceApi
 from conductor.client.http.models import TaskDef, WorkflowDef, WorkflowTask
-from conductor.client.http.models.schema_def import SchemaDef, SchemaType
 from conductor.client.orkes.orkes_metadata_client import OrkesMetadataClient
-from conductor.client.orkes.orkes_schema_client import OrkesSchemaClient
 
 TASK_NAME = 'task-test-sdk'
 WORKFLOW_NAME = 'sdk-workflow-test-0'
@@ -32,7 +28,7 @@ task = {
     "response_timeout_seconds": 600,
     "rate_limit_per_frequency": 0,
     "rate_limit_frequency_in_seconds": 1,
-    "owner_email": "viren@orkes.io",
+    "owner_email": "test@conductoross.io",
     "poll_timeout_seconds": 3600,
     "input_keys": [],
     "output_keys": [],
@@ -66,7 +62,7 @@ workflow = {
     "schema_version": 2,
     "restartable": True,
     "workflow_status_listener_enabled": False,
-    "owner_email": "viren@orkes.io",
+    "owner_email": "test@conductoross.io",
     "timeout_policy": "ALERT_ONLY",
     "timeout_seconds": 0,
     "failure_workflow": "",
@@ -101,7 +97,6 @@ class TestOrkesMetadataClient(unittest.TestCase):
         )
 
     def setUp(self):
-        self.taskDef = TaskDef(name='task-test-sdk-0')
         logging.disable(logging.CRITICAL)
 
     def tearDown(self):

--- a/tests/integration/metadata/test_task_metadata_service.py
+++ b/tests/integration/metadata/test_task_metadata_service.py
@@ -110,10 +110,27 @@ class TestOrkesMetadataClient(unittest.TestCase):
         self.assertEqual(response.output_schema, None)
         self.assertEqual(response.enforce_schema, False)
 
+    def _register_or_update(self, workflow_def):
+        # Plain OSS Conductor's create endpoint does not honor `overwrite=true`
+        # the way Orkes Enterprise does (confirmed empirically via a direct
+        # curl bypassing the SDK: POST /metadata/workflow?overwrite=true still
+        # 500s "already exists" for a name+version that's already
+        # registered -- from a prior test run against the same long-lived
+        # server, or a second registration of the same version within this
+        # very test). Fall back to the update endpoint (PUT
+        # /metadata/workflow), which does apply the new definition on both
+        # OSS and Enterprise.
+        try:
+            self.metadata_client.register_workflow_def(workflow_def=workflow_def)
+        except Exception as e:
+            if 'already exists' not in str(e):
+                raise
+            self.metadata_client.update_workflow_def(workflow_def=workflow_def)
+
     def test_register_workflow_def(self):
         workflow_def = WorkflowDef(**workflow)
 
-        self.metadata_client.register_workflow_def(workflow_def=workflow_def)
+        self._register_or_update(workflow_def)
         response = self.metadata_client.get_workflow_def(name=WORKFLOW_NAME)
         self.assertEqual(response.name, WORKFLOW_NAME)
         self.assertEqual(response.input_schema.name, schema['name'])
@@ -122,7 +139,7 @@ class TestOrkesMetadataClient(unittest.TestCase):
 
         no_schema_wf = WorkflowDef(name='workflow-sdk-no-schema', tasks=[
             WorkflowTask(name='test', task_reference_name='test_ref', task_definition=TaskDef())])
-        self.metadata_client.register_workflow_def(workflow_def=no_schema_wf)
+        self._register_or_update(no_schema_wf)
         response = self.metadata_client.get_workflow_def(name=no_schema_wf.name)
         self.assertEqual(response.name, no_schema_wf.name)
         self.assertEqual(len(response.tasks), 1)
@@ -132,7 +149,7 @@ class TestOrkesMetadataClient(unittest.TestCase):
 
         no_schema_wf = WorkflowDef(name='workflow-sdk-no-schema', tasks=[
             WorkflowTask(name='test', task_reference_name='test_ref')])
-        self.metadata_client.register_workflow_def(workflow_def=no_schema_wf)
+        self._register_or_update(no_schema_wf)
         response = self.metadata_client.get_workflow_def(name=no_schema_wf.name)
         self.assertEqual(response.name, no_schema_wf.name)
         self.assertEqual(len(response.tasks), 1)

--- a/tests/integration/metadata/test_task_metadata_service.py
+++ b/tests/integration/metadata/test_task_metadata_service.py
@@ -84,8 +84,21 @@ class TestOrkesMetadataClient(unittest.TestCase):
         from tests.integration.conftest import skip_if_server_unavailable
         skip_if_server_unavailable()
 
-        configuration = Configuration()
-        cls.metadata_client = OrkesMetadataClient(configuration)
+        cls.configuration = Configuration()
+        cls.metadata_client = OrkesMetadataClient(cls.configuration)
+
+    @classmethod
+    def tearDownClass(cls):
+        # These defs used to be left registered after every run, so the next run
+        # against the same long-lived server hit "already exists" on
+        # re-registration. cleanup_metadata swallows its own failures (see its
+        # docstring), so this can never turn a passing suite red.
+        from tests.integration.conftest import cleanup_metadata
+        cleanup_metadata(
+            cls.configuration,
+            task_defs=(TASK_NAME, 'task-sdk-no-schema'),
+            workflow_defs=(WORKFLOW_NAME, 'workflow-sdk-no-schema'),
+        )
 
     def setUp(self):
         self.taskDef = TaskDef(name='task-test-sdk-0')
@@ -114,12 +127,21 @@ class TestOrkesMetadataClient(unittest.TestCase):
         # Plain OSS Conductor's create endpoint does not honor `overwrite=true`
         # the way Orkes Enterprise does (confirmed empirically via a direct
         # curl bypassing the SDK: POST /metadata/workflow?overwrite=true still
-        # 500s "already exists" for a name+version that's already
-        # registered -- from a prior test run against the same long-lived
-        # server, or a second registration of the same version within this
-        # very test). Fall back to the update endpoint (PUT
-        # /metadata/workflow), which does apply the new definition on both
-        # OSS and Enterprise.
+        # 500s "already exists" for a name+version that's already registered --
+        # notably the second registration of 'workflow-sdk-no-schema' below,
+        # which re-registers the same name+version with a changed definition).
+        # Fall back to the update endpoint (PUT /metadata/workflow), which does
+        # apply the new definition.
+        #
+        # Gated on OSS on purpose: what this test covers is that
+        # register_workflow_def (POST create, overwrite=true) works. Falling
+        # back to update_workflow_def (PUT update1) is a *different* endpoint,
+        # so leaving the fallback ungated would let this test pass on Orkes
+        # even if create-with-overwrite regressed.
+        from tests.integration.conftest import is_oss
+        if not is_oss():
+            self.metadata_client.register_workflow_def(workflow_def=workflow_def)
+            return
         try:
             self.metadata_client.register_workflow_def(workflow_def=workflow_def)
         except Exception as e:

--- a/tests/integration/resources/test_data/complex_wf_signal_test.json
+++ b/tests/integration/resources/test_data/complex_wf_signal_test.json
@@ -56,7 +56,7 @@
   "schemaVersion": 2,
   "restartable": true,
   "workflowStatusListenerEnabled": false,
-  "ownerEmail": "shailesh.padave@orkes.io",
+  "ownerEmail": "test@conductoross.io",
   "timeoutPolicy": "ALERT_ONLY",
   "timeoutSeconds": 0,
   "variables": {},

--- a/tests/integration/resources/test_data/complex_wf_signal_test_oss.json
+++ b/tests/integration/resources/test_data/complex_wf_signal_test_oss.json
@@ -1,0 +1,65 @@
+{
+  "createTime": 1744299182957,
+  "updateTime": 1744299435683,
+  "name": "complex_wf_signal_test_oss",
+  "description": "http_wait_signal_test -- OSS-compatible variant of complex_wf_signal_test using WAIT instead of YIELD (YIELD is Orkes-Enterprise-only)",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "http",
+      "taskReferenceName": "http_ref",
+      "inputParameters": {
+        "uri": "http://httpbin:8081/api/hello?name=test1",
+        "method": "GET",
+        "accept": "application/json",
+        "contentType": "application/json",
+        "encode": true
+      },
+      "type": "HTTP",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": [],
+      "onStateChange": {},
+      "permissive": false
+    },
+    {
+      "name": "sub_workflow",
+      "taskReferenceName": "sub_workflow_ref",
+      "inputParameters": {},
+      "type": "SUB_WORKFLOW",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "subWorkflowParam": {
+        "name": "complex_wf_signal_test_subworkflow_1_oss",
+        "version": 1
+      },
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": [],
+      "onStateChange": {},
+      "permissive": false
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "failureWorkflow": "",
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "ownerEmail": "shailesh.padave@orkes.io",
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "variables": {},
+  "inputTemplate": {},
+  "enforceSchema": true
+}

--- a/tests/integration/resources/test_data/complex_wf_signal_test_oss.json
+++ b/tests/integration/resources/test_data/complex_wf_signal_test_oss.json
@@ -56,7 +56,7 @@
   "schemaVersion": 2,
   "restartable": true,
   "workflowStatusListenerEnabled": false,
-  "ownerEmail": "shailesh.padave@orkes.io",
+  "ownerEmail": "test@conductoross.io",
   "timeoutPolicy": "ALERT_ONLY",
   "timeoutSeconds": 0,
   "variables": {},

--- a/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_1.json
+++ b/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_1.json
@@ -73,7 +73,7 @@
   "schemaVersion": 2,
   "restartable": true,
   "workflowStatusListenerEnabled": false,
-  "ownerEmail": "shailesh.padave@orkes.io",
+  "ownerEmail": "test@conductoross.io",
   "timeoutPolicy": "ALERT_ONLY",
   "timeoutSeconds": 0,
   "variables": {},

--- a/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_1_oss.json
+++ b/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_1_oss.json
@@ -73,7 +73,7 @@
   "schemaVersion": 2,
   "restartable": true,
   "workflowStatusListenerEnabled": false,
-  "ownerEmail": "shailesh.padave@orkes.io",
+  "ownerEmail": "test@conductoross.io",
   "timeoutPolicy": "ALERT_ONLY",
   "timeoutSeconds": 0,
   "variables": {},

--- a/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_1_oss.json
+++ b/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_1_oss.json
@@ -1,0 +1,82 @@
+{
+  "createTime": 1744299356718,
+  "updateTime": 1744287643769,
+  "name": "complex_wf_signal_test_subworkflow_1_oss",
+  "description": "complex_wf_signal_test_subworkflow_1_oss -- OSS-compatible variant using WAIT instead of YIELD",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "http",
+      "taskReferenceName": "http_ref",
+      "inputParameters": {
+        "uri": "http://httpbin:8081/api/hello?name=test1",
+        "method": "GET",
+        "accept": "application/json",
+        "contentType": "application/json",
+        "encode": true
+      },
+      "type": "HTTP",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": [],
+      "onStateChange": {},
+      "permissive": false
+    },
+    {
+      "name": "wait",
+      "taskReferenceName": "simple_ref_1",
+      "inputParameters": {},
+      "type": "WAIT",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": [],
+      "onStateChange": {},
+      "permissive": false
+    },
+    {
+      "name": "sub_workflow",
+      "taskReferenceName": "sub_workflow_ref",
+      "inputParameters": {},
+      "type": "SUB_WORKFLOW",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "subWorkflowParam": {
+        "name": "complex_wf_signal_test_subworkflow_2_oss",
+        "version": 1
+      },
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": [],
+      "onStateChange": {},
+      "permissive": false
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "failureWorkflow": "",
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "ownerEmail": "shailesh.padave@orkes.io",
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "variables": {},
+  "inputTemplate": {},
+  "enforceSchema": true
+}

--- a/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_2.json
+++ b/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_2.json
@@ -52,7 +52,7 @@
   "schemaVersion": 2,
   "restartable": true,
   "workflowStatusListenerEnabled": false,
-  "ownerEmail": "shailesh.padave@orkes.io",
+  "ownerEmail": "test@conductoross.io",
   "timeoutPolicy": "ALERT_ONLY",
   "timeoutSeconds": 0,
   "variables": {},

--- a/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_2_oss.json
+++ b/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_2_oss.json
@@ -52,7 +52,7 @@
   "schemaVersion": 2,
   "restartable": true,
   "workflowStatusListenerEnabled": false,
-  "ownerEmail": "shailesh.padave@orkes.io",
+  "ownerEmail": "test@conductoross.io",
   "timeoutPolicy": "ALERT_ONLY",
   "timeoutSeconds": 0,
   "variables": {},

--- a/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_2_oss.json
+++ b/tests/integration/resources/test_data/complex_wf_signal_test_subworkflow_2_oss.json
@@ -1,0 +1,61 @@
+{
+  "createTime": 1744299371396,
+  "updateTime": 0,
+  "name": "complex_wf_signal_test_subworkflow_2_oss",
+  "description": "complex_wf_signal_test_subworkflow_2_oss -- OSS-compatible variant using WAIT instead of YIELD",
+  "version": 1,
+  "tasks": [
+    {
+      "name": "http",
+      "taskReferenceName": "http_ref",
+      "inputParameters": {
+        "uri": "http://httpbin:8081/api/hello?name=test1",
+        "method": "GET",
+        "accept": "application/json",
+        "contentType": "application/json",
+        "encode": true
+      },
+      "type": "HTTP",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": [],
+      "onStateChange": {},
+      "permissive": false
+    },
+    {
+      "name": "wait",
+      "taskReferenceName": "simple_ref_1",
+      "inputParameters": {},
+      "type": "WAIT",
+      "decisionCases": {},
+      "defaultCase": [],
+      "forkTasks": [],
+      "startDelay": 0,
+      "joinOn": [],
+      "optional": false,
+      "defaultExclusiveJoinTask": [],
+      "asyncComplete": false,
+      "loopOver": [],
+      "onStateChange": {},
+      "permissive": false
+    }
+  ],
+  "inputParameters": [],
+  "outputParameters": {},
+  "failureWorkflow": "",
+  "schemaVersion": 2,
+  "restartable": true,
+  "workflowStatusListenerEnabled": false,
+  "ownerEmail": "shailesh.padave@orkes.io",
+  "timeoutPolicy": "ALERT_ONLY",
+  "timeoutSeconds": 0,
+  "variables": {},
+  "inputTemplate": {},
+  "enforceSchema": true
+}

--- a/tests/integration/test_authorization_client_intg.py
+++ b/tests/integration/test_authorization_client_intg.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import unittest
 import time
 from typing import List
@@ -19,6 +18,7 @@ from conductor.client.orkes.models.access_type import AccessType
 from conductor.client.orkes.models.metadata_tag import MetadataTag
 from conductor.client.http.rest import ApiException
 from conductor.client.orkes.orkes_authorization_client import OrkesAuthorizationClient
+from tests.integration.conftest import is_oss
 
 logger = logging.getLogger(
     Configuration.get_logging_formatted_name(__name__)
@@ -33,7 +33,7 @@ def get_configuration():
 
 
 @unittest.skipIf(
-    os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss',
+    is_oss(),
     "The Authorization APIs (applications/users/groups/roles/permissions) "
     "are not implemented by plain OSS Conductor -- confirmed empirically "
     "(404 'No static resource api/applications|users|groups|...')."

--- a/tests/integration/test_authorization_client_intg.py
+++ b/tests/integration/test_authorization_client_intg.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import unittest
 import time
 from typing import List
@@ -31,6 +32,12 @@ def get_configuration():
     return configuration
 
 
+@unittest.skipIf(
+    os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss',
+    "The Authorization APIs (applications/users/groups/roles/permissions) "
+    "are not implemented by plain OSS Conductor -- confirmed empirically "
+    "(404 'No static resource api/applications|users|groups|...')."
+)
 class TestOrkesAuthorizationClientIntg(unittest.TestCase):
     """Comprehensive integration test for OrkesAuthorizationClient.
 

--- a/tests/integration/test_authorization_complete.py
+++ b/tests/integration/test_authorization_complete.py
@@ -11,6 +11,7 @@ Run with:
     python -m pytest tests/integration/test_authorization_complete.py -v
 """
 
+import os
 import pytest
 import uuid
 import time
@@ -28,6 +29,14 @@ from conductor.client.http.models.authentication_config import AuthenticationCon
 from conductor.client.orkes.models.access_type import AccessType
 from conductor.client.orkes.models.metadata_tag import MetadataTag
 from conductor.client.http.rest import ApiException, RestException
+
+# The Authorization APIs (applications/users/groups/roles/permissions) are
+# not implemented by plain OSS Conductor -- confirmed empirically (404 'No
+# static resource api/applications|users|groups|...').
+pytestmark = pytest.mark.skipif(
+    os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss',
+    reason="Authorization APIs are Orkes-Enterprise-only (confirmed empirically not on plain OSS Conductor)"
+)
 
 
 @pytest.fixture(scope="module")

--- a/tests/integration/test_authorization_complete.py
+++ b/tests/integration/test_authorization_complete.py
@@ -11,7 +11,6 @@ Run with:
     python -m pytest tests/integration/test_authorization_complete.py -v
 """
 
-import os
 import pytest
 import uuid
 import time
@@ -29,12 +28,13 @@ from conductor.client.http.models.authentication_config import AuthenticationCon
 from conductor.client.orkes.models.access_type import AccessType
 from conductor.client.orkes.models.metadata_tag import MetadataTag
 from conductor.client.http.rest import ApiException, RestException
+from tests.integration.conftest import is_oss
 
 # The Authorization APIs (applications/users/groups/roles/permissions) are
 # not implemented by plain OSS Conductor -- confirmed empirically (404 'No
 # static resource api/applications|users|groups|...').
 pytestmark = pytest.mark.skipif(
-    os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss',
+    is_oss(),
     reason="Authorization APIs are Orkes-Enterprise-only (confirmed empirically not on plain OSS Conductor)"
 )
 

--- a/tests/integration/workflow/test_workflow_execution.py
+++ b/tests/integration/workflow/test_workflow_execution.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from time import sleep
 
@@ -129,7 +130,11 @@ def scenario_workflow_registration(workflow_executor: WorkflowExecutor):
             workflow.name, workflow.version
         )
     except Exception as e:
-        if '404' not in str(e):
+        # Best-effort cleanup: tolerate "doesn't exist" regardless of how the
+        # server reports it. Orkes Enterprise returns 404; plain OSS Conductor
+        # returns a 500 with a "No such workflow definition" message instead
+        # (confirmed empirically) -- treat both as success for this purpose.
+        if '404' not in str(e) and 'No such workflow definition' not in str(e):
             raise e
     workflow.register(overwrite=True) == None
     workflow_executor.register_workflow(
@@ -289,11 +294,19 @@ def validate_workflow_status(workflow_id: str, workflow_executor: WorkflowExecut
             f'workflow_id: {workflow_id}, tasks: '
             f'{_describe_tasks(workflow_id, workflow_executor)}'
         )
-    workflow_status = workflow_executor.get_workflow_status(
-        workflow_id=workflow_id,
-        include_output=False,
-        include_variables=False,
-    )
+    try:
+        workflow_status = workflow_executor.get_workflow_status(
+            workflow_id=workflow_id,
+            include_output=False,
+            include_variables=False,
+        )
+    except Exception as e:
+        # GET /workflow/{id}/status is not implemented on plain OSS Conductor
+        # (confirmed empirically: 404 "No static resource ..."); the
+        # equivalent COMPLETED assertion above already covers this case.
+        if '404' in str(e):
+            return
+        raise
     if workflow_status.status != 'COMPLETED':
         raise Exception(
             f'workflow expected to be COMPLETED, but received {workflow_status.status}, workflow_id: {workflow_id}'
@@ -513,6 +526,38 @@ def run_signal_tests(configuration: Configuration, workflow_executor: WorkflowEx
     actually sent — no double-signalling of a single workflow.
     """
     logger.info('START: Signal API tests using WorkflowExecutor')
+
+    if os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss':
+        # The POST /tasks/{workflowId}/{status}/signal(/sync) endpoints
+        # themselves ARE implemented on plain OSS Conductor and work
+        # correctly -- confirmed empirically with a probe workflow using a
+        # real WAIT task: all four return strategies (TARGET_WORKFLOW,
+        # BLOCKING_WORKFLOW, BLOCKING_TASK, BLOCKING_TASK_INPUT) signal it
+        # successfully and return 200 with a well-formed SignalResponse.
+        #
+        # The gap is in these specific test fixtures: complex_wf_signal_test
+        # (and its sub-workflows) use a "YIELD" task as the intended
+        # blocking/pause point, but YIELD is an Orkes-Enterprise-only task
+        # type that isn't in OSS's TaskType enum at all, so OSS never
+        # transitions it into the WAIT-task state that
+        # TaskServiceImpl.findPendingBlockingTask() looks for (it only
+        # recognizes a non-terminal WAIT task, optionally nested inside a
+        # SUB_WORKFLOW). The workflow just parks on the YIELD task forever,
+        # and every signal attempt 404s with "Found no blocked task in
+        # workflow ... to signal" -- confirmed by reading
+        # TaskServiceImpl/TaskResource in the conductor-oss source and by
+        # reproducing the exact same 404 against a hand-built WAIT-based
+        # workflow once the WAIT task is later completed (no task left to
+        # find). So: gate out these YIELD-based scenarios as Orkes-only for
+        # now (rewriting the fixtures to use WAIT would be the real fix, but
+        # that's a bigger change than this OSS CI job warrants).
+        logger.warning(
+            'Skipping Signal API tests: the complex_wf_signal_test fixtures use the '
+            'Orkes-only YIELD task type as their blocking point, which plain OSS Conductor '
+            'never resolves to a signalable task (confirmed empirically) -- the signal/sync '
+            'REST API itself does work on OSS with a real WAIT task'
+        )
+        return
 
     try:
         # Register signal test workflows (same as original test)

--- a/tests/integration/workflow/test_workflow_execution.py
+++ b/tests/integration/workflow/test_workflow_execution.py
@@ -24,6 +24,17 @@ COMPLEX_WF_NAME = 'complex_wf_signal_test'
 SUB_WF_1_NAME = 'complex_wf_signal_test_subworkflow_1'
 SUB_WF_2_NAME = 'complex_wf_signal_test_subworkflow_2'
 
+# OSS-compatible variants of the fixtures above: identical shape (HTTP task,
+# then a nested SUB_WORKFLOW chain that parks on a blocking task twice before
+# completing), except the blocking task is a WAIT instead of a YIELD. YIELD is
+# an Orkes-Enterprise-only task type that plain OSS Conductor doesn't
+# recognize at all, so it never reaches the "pending blocking task" state the
+# Signal API looks for; WAIT is a real OSS task type that does (confirmed
+# empirically -- see the comment in run_signal_tests below).
+COMPLEX_WF_NAME_OSS = 'complex_wf_signal_test_oss'
+SUB_WF_1_NAME_OSS = 'complex_wf_signal_test_subworkflow_1_oss'
+SUB_WF_2_NAME_OSS = 'complex_wf_signal_test_subworkflow_2_oss'
+
 # Max time to wait for the batch of simple workflows to reach a terminal state.
 # These normally finish in seconds, but on a loaded shared server we've observed
 # them take ~30s+; the old ~12s budget (5s sleep + 1+2+4 retry backoff) produced
@@ -516,6 +527,37 @@ def _wait_for_workflow_completion(workflow_executor: WorkflowExecutor, workflow_
 
 # ===== SIGNAL TESTS =====
 
+def _is_oss() -> bool:
+    return os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss'
+
+
+def _signal_test_workflow_names():
+    """(complex_wf_name, sub_wf_1_name, sub_wf_2_name) for the fixture set
+    appropriate to the server under test.
+
+    On plain OSS Conductor the YIELD-based fixtures never reach a signalable
+    state: YIELD is an Orkes-Enterprise-only task type that isn't in OSS's
+    TaskType enum at all, so OSS never transitions it into the WAIT-task
+    state that TaskServiceImpl.findPendingBlockingTask() looks for (it only
+    recognizes a non-terminal WAIT task, optionally nested inside a
+    SUB_WORKFLOW) -- confirmed empirically by reading
+    TaskServiceImpl/TaskResource in the conductor-oss source and by
+    reproducing the exact 404 ("Found no blocked task in workflow ... to
+    signal") against the YIELD fixtures, then confirming a hand-built
+    WAIT-based workflow signals successfully instead. The POST
+    /tasks/{workflowId}/{status}/signal(/sync) endpoints themselves ARE
+    implemented on plain OSS Conductor and work correctly with a real WAIT
+    task -- all four return strategies (TARGET_WORKFLOW, BLOCKING_WORKFLOW,
+    BLOCKING_TASK, BLOCKING_TASK_INPUT) signal it successfully and return 200
+    with a well-formed SignalResponse. So on OSS we swap in the
+    _OSS-suffixed fixtures, which are identical except the blocking task is
+    WAIT instead of YIELD.
+    """
+    if _is_oss():
+        return COMPLEX_WF_NAME_OSS, SUB_WF_1_NAME_OSS, SUB_WF_2_NAME_OSS
+    return COMPLEX_WF_NAME, SUB_WF_1_NAME, SUB_WF_2_NAME
+
+
 def run_signal_tests(configuration: Configuration, workflow_executor: WorkflowExecutor,
                      deadline=None):
     """Run all signal API tests using WorkflowExecutor methods.
@@ -524,40 +566,12 @@ def run_signal_tests(configuration: Configuration, workflow_executor: WorkflowEx
     retry_scenario): a retry starts a fresh workflow and issues a fresh sync
     signal, so the asserted SignalResponse is always from a signal this attempt
     actually sent — no double-signalling of a single workflow.
+
+    The workflow fixtures used here differ between Orkes Enterprise and plain
+    OSS Conductor -- see _signal_test_workflow_names().
     """
     logger.info('START: Signal API tests using WorkflowExecutor')
-
-    if os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss':
-        # The POST /tasks/{workflowId}/{status}/signal(/sync) endpoints
-        # themselves ARE implemented on plain OSS Conductor and work
-        # correctly -- confirmed empirically with a probe workflow using a
-        # real WAIT task: all four return strategies (TARGET_WORKFLOW,
-        # BLOCKING_WORKFLOW, BLOCKING_TASK, BLOCKING_TASK_INPUT) signal it
-        # successfully and return 200 with a well-formed SignalResponse.
-        #
-        # The gap is in these specific test fixtures: complex_wf_signal_test
-        # (and its sub-workflows) use a "YIELD" task as the intended
-        # blocking/pause point, but YIELD is an Orkes-Enterprise-only task
-        # type that isn't in OSS's TaskType enum at all, so OSS never
-        # transitions it into the WAIT-task state that
-        # TaskServiceImpl.findPendingBlockingTask() looks for (it only
-        # recognizes a non-terminal WAIT task, optionally nested inside a
-        # SUB_WORKFLOW). The workflow just parks on the YIELD task forever,
-        # and every signal attempt 404s with "Found no blocked task in
-        # workflow ... to signal" -- confirmed by reading
-        # TaskServiceImpl/TaskResource in the conductor-oss source and by
-        # reproducing the exact same 404 against a hand-built WAIT-based
-        # workflow once the WAIT task is later completed (no task left to
-        # find). So: gate out these YIELD-based scenarios as Orkes-only for
-        # now (rewriting the fixtures to use WAIT would be the real fix, but
-        # that's a bigger change than this OSS CI job warrants).
-        logger.warning(
-            'Skipping Signal API tests: the complex_wf_signal_test fixtures use the '
-            'Orkes-only YIELD task type as their blocking point, which plain OSS Conductor '
-            'never resolves to a signalable task (confirmed empirically) -- the signal/sync '
-            'REST API itself does work on OSS with a real WAIT task'
-        )
-        return
+    complex_wf_name, sub_wf_1_name, sub_wf_2_name = _signal_test_workflow_names()
 
     try:
         # Register signal test workflows (same as original test)
@@ -596,13 +610,13 @@ def run_signal_tests(configuration: Configuration, workflow_executor: WorkflowEx
         # Cleanup
         try:
             workflow_executor.metadata_client.unregister_workflow_def(
-                COMPLEX_WF_NAME, 1
+                complex_wf_name, 1
             )
             workflow_executor.metadata_client.unregister_workflow_def(
-                SUB_WF_1_NAME, 1
+                sub_wf_1_name, 1
             )
             workflow_executor.metadata_client.unregister_workflow_def(
-                SUB_WF_2_NAME, 1
+                sub_wf_2_name, 1
             )
         except Exception as cleanup_error:
             logger.warning(f'Cleanup failed: {cleanup_error}')
@@ -613,7 +627,8 @@ def run_signal_tests(configuration: Configuration, workflow_executor: WorkflowEx
 def _register_signal_test_workflows(workflow_executor: WorkflowExecutor):
     """Register the complex signal test workflows from JSON files"""
     import json
-    import os
+
+    complex_wf_name, sub_wf_1_name, sub_wf_2_name = _signal_test_workflow_names()
 
     def _get_workflow_definition(path):
         """Get workflow definition from JSON file, following existing pattern"""
@@ -645,18 +660,18 @@ def _register_signal_test_workflows(workflow_executor: WorkflowExecutor):
 
     try:
         # Register main workflow
-        complex_wf_def = _get_workflow_definition(f'tests/integration/resources/test_data/{COMPLEX_WF_NAME}.json')
+        complex_wf_def = _get_workflow_definition(f'tests/integration/resources/test_data/{complex_wf_name}.json')
         workflow_executor.metadata_client.update1(body=[complex_wf_def], overwrite=True)
-        logger.info(f'Registered workflow: {COMPLEX_WF_NAME}')
+        logger.info(f'Registered workflow: {complex_wf_name}')
 
         # Register subworkflows
-        sub_wf1_def = _get_workflow_definition(f'tests/integration/resources/test_data/{SUB_WF_1_NAME}.json')
+        sub_wf1_def = _get_workflow_definition(f'tests/integration/resources/test_data/{sub_wf_1_name}.json')
         workflow_executor.metadata_client.update1(body=[sub_wf1_def], overwrite=True)
-        logger.info(f'Registered workflow: {SUB_WF_1_NAME}')
+        logger.info(f'Registered workflow: {sub_wf_1_name}')
 
-        sub_wf2_def = _get_workflow_definition(f'tests/integration/resources/test_data/{SUB_WF_2_NAME}.json')
+        sub_wf2_def = _get_workflow_definition(f'tests/integration/resources/test_data/{sub_wf_2_name}.json')
         workflow_executor.metadata_client.update1(body=[sub_wf2_def], overwrite=True)
-        logger.info(f'Registered workflow: {SUB_WF_2_NAME}')
+        logger.info(f'Registered workflow: {sub_wf_2_name}')
 
     except Exception as e:
         logger.warning(f'Some workflows may already be registered: {e}')
@@ -667,9 +682,10 @@ def _register_signal_test_workflows(workflow_executor: WorkflowExecutor):
 
 def _start_complex_workflow(workflow_executor: WorkflowExecutor) -> str:
     """Start complex workflow and return workflow ID"""
+    complex_wf_name, _, _ = _signal_test_workflow_names()
     try:
         start_request = StartWorkflowRequest(
-            name=COMPLEX_WF_NAME,
+            name=complex_wf_name,
             version=1,
             input={}
         )
@@ -689,6 +705,56 @@ def _start_complex_workflow(workflow_executor: WorkflowExecutor) -> str:
         raise
 
 
+# The task type(s) these fixtures actually use as their intended "park here
+# until signaled" point: YIELD (Orkes Enterprise, complex_wf_signal_test) or
+# WAIT (plain OSS Conductor, complex_wf_signal_test_oss) -- see
+# _signal_test_workflow_names(). Deliberately narrower than "any non-terminal
+# leaf task": an ordinary task that's merely mid-flight (e.g. the HTTP task
+# that runs *before* the blocking task) is also transiently SCHEDULED/
+# IN_PROGRESS, and matching on that caused a false-positive "blocked" result
+# that raced the real block -- confirmed empirically as a 404 "Found no
+# blocked task in workflow ... to signal" moments after this incorrectly
+# reported the workflow as ready to signal.
+_BLOCKING_TASK_TYPES = ('WAIT', 'YIELD')
+
+
+def _find_blocking_leaf_tasks(workflow_executor: WorkflowExecutor, workflow_id: str,
+                              depth: int = 0, max_depth: int = 5):
+    """Recursively find the actual blocking task(s) (see _BLOCKING_TASK_TYPES)
+    that are non-terminal, descending into any IN_PROGRESS SUB_WORKFLOW's own
+    tasks.
+
+    This mirrors the server's own signal-target resolution (TaskServiceImpl.
+    findPendingBlockingTask on the OSS side descends into running sub-workflows
+    the same way looking specifically for a pending WAIT task), which matters
+    for complex_wf_signal_test(_oss): the *outer* workflow's SUB_WORKFLOW task
+    itself flips to IN_PROGRESS essentially the instant it's scheduled, well
+    before the decider has actually started the nested workflow and run it as
+    far as its own blocking task -- so a signal issued right then races the
+    real block. Restricting to _BLOCKING_TASK_TYPES (rather than "any
+    non-terminal task") avoids also raced-matching on an ordinary task that
+    happens to be transiently IN_PROGRESS (e.g. the HTTP task preceding the
+    blocking task in these fixtures).
+
+    Returns [] if nothing is blocked yet (or max_depth is exceeded).
+    """
+    if depth > max_depth:
+        return []
+    workflow = workflow_executor.get_workflow(workflow_id=workflow_id, include_tasks=True)
+    tasks = workflow.tasks or []
+    for t in tasks:
+        if (getattr(t, 'task_type', None) == 'SUB_WORKFLOW'
+                and getattr(t, 'status', None) == 'IN_PROGRESS'
+                and getattr(t, 'sub_workflow_id', None)):
+            nested = _find_blocking_leaf_tasks(
+                workflow_executor, t.sub_workflow_id, depth + 1, max_depth)
+            if nested:
+                return nested
+    return [t for t in tasks
+            if getattr(t, 'task_type', None) in _BLOCKING_TASK_TYPES
+            and getattr(t, 'status', None) in ('SCHEDULED', 'IN_PROGRESS')]
+
+
 def _wait_for_blocking_task(workflow_executor: WorkflowExecutor, workflow_id: str,
                             timeout: float = 30.0, interval: float = 0.5):
     """Wait until the workflow is actually parked on a task, before signalling.
@@ -698,19 +764,20 @@ def _wait_for_blocking_task(workflow_executor: WorkflowExecutor, workflow_id: st
     workflow needs a moment to run its first task and schedule that one, and the
     fixed sleep(0.5) this replaces was not enough on a loaded shared server: the
     signal came back with no responseType at all, surfacing as the intermittent
-    "Expected BLOCKING_TASK, got None".
+    "Expected BLOCKING_TASK, got None". See _find_blocking_leaf_tasks for why
+    this needs to descend into nested sub-workflows rather than just checking
+    the outer workflow's own task list.
 
     Returns the tasks last seen so callers can report them if the wait times out.
     """
     deadline = time.time() + timeout
     tasks = []
     while time.time() < deadline:
-        workflow = workflow_executor.get_workflow(workflow_id=workflow_id,
-                                                  include_tasks=True)
-        tasks = workflow.tasks or []
-        if any(getattr(t, 'status', None) in ('SCHEDULED', 'IN_PROGRESS')
-               for t in tasks):
+        tasks = _find_blocking_leaf_tasks(workflow_executor, workflow_id)
+        if tasks:
             return tasks
+        workflow = workflow_executor.get_workflow(workflow_id=workflow_id,
+                                                  include_tasks=False)
         if getattr(workflow, 'status', None) not in ('RUNNING', 'PAUSED'):
             # Already terminal: nothing is going to block, so stop waiting and
             # let the caller's assertion report the real state.

--- a/tests/integration/workflow/test_workflow_execution.py
+++ b/tests/integration/workflow/test_workflow_execution.py
@@ -51,6 +51,24 @@ logger = logging.getLogger(
 
 def run_workflow_execution_tests(configuration: Configuration, workflow_executor: WorkflowExecutor,
                                  deadline=None):
+    # Register the task def before any worker polls for it. Without this the
+    # def on the server is whatever some other suite last registered -- in
+    # practice a bare TaskDef(name=...), which the server fills in with its
+    # default responseTimeoutSeconds of 3600. A worker that leases a task and
+    # then stops updating it (a transport blip against the shared server, or the
+    # job simply ending) therefore holds it for an hour before the server
+    # reclaims it: far past this scenario's WORKFLOW_COMPLETION_MAX_WAIT_SECONDS
+    # budget, so the workflow sits IN_PROGRESS and the test fails. Registering
+    # generate_tasks_defs() sets response_timeout_seconds=2, so the server
+    # requeues the task in seconds and another worker picks it up.
+    #
+    # Note workflow_executor.metadata_client is a MetadataResourceApi, whose
+    # register_task_def takes the *list* of defs. (OrkesMetadataClient has a
+    # same-named method that takes a single TaskDef and wraps it itself --
+    # passing one def here instead yields a 500 "Cannot deserialize ...
+    # ArrayList<TaskDef> from Object value".)
+    workflow_executor.metadata_client.register_task_def(generate_tasks_defs())
+
     workers = [
         ClassWorker(TASK_NAME),
         ClassWorkerWithDomain(TASK_NAME),

--- a/tests/integration/workflow/test_workflow_execution.py
+++ b/tests/integration/workflow/test_workflow_execution.py
@@ -315,7 +315,9 @@ def validate_workflow_status(workflow_id: str, workflow_executor: WorkflowExecut
         # GET /workflow/{id}/status is not implemented on plain OSS Conductor
         # (confirmed empirically: 404 "No static resource ..."); the
         # equivalent COMPLETED assertion above already covers this case.
-        if '404' in str(e):
+        # Gated on OSS on purpose: the endpoint does exist on Orkes, so an
+        # ungated swallow would turn a genuine 404 there into a silent pass.
+        if _is_oss() and '404' in str(e):
             return
         raise
     if workflow_status.status != 'COMPLETED':
@@ -528,7 +530,8 @@ def _wait_for_workflow_completion(workflow_executor: WorkflowExecutor, workflow_
 # ===== SIGNAL TESTS =====
 
 def _is_oss() -> bool:
-    return os.environ.get('CONDUCTOR_SERVER_TYPE') == 'oss'
+    from tests.integration.conftest import is_oss
+    return is_oss()
 
 
 def _signal_test_workflow_names():

--- a/tests/integration/workflow/test_workflow_execution.py
+++ b/tests/integration/workflow/test_workflow_execution.py
@@ -739,23 +739,29 @@ def _find_blocking_leaf_tasks(workflow_executor: WorkflowExecutor, workflow_id: 
     happens to be transiently IN_PROGRESS (e.g. the HTTP task preceding the
     blocking task in these fixtures).
 
-    Returns [] if nothing is blocked yet (or max_depth is exceeded).
+    Returns (blocking_tasks, workflow), where blocking_tasks is [] if nothing is
+    blocked yet, and workflow is the Workflow fetched at *this* level (None only
+    if max_depth was exceeded). Handing the workflow back lets the caller read
+    its status and task list without paying for a second get_workflow: this is
+    polled every `interval` seconds, so re-fetching the same object to read one
+    field doubled the request count for the whole wait.
     """
     if depth > max_depth:
-        return []
+        return [], None
     workflow = workflow_executor.get_workflow(workflow_id=workflow_id, include_tasks=True)
     tasks = workflow.tasks or []
     for t in tasks:
         if (getattr(t, 'task_type', None) == 'SUB_WORKFLOW'
                 and getattr(t, 'status', None) == 'IN_PROGRESS'
                 and getattr(t, 'sub_workflow_id', None)):
-            nested = _find_blocking_leaf_tasks(
+            nested, _ = _find_blocking_leaf_tasks(
                 workflow_executor, t.sub_workflow_id, depth + 1, max_depth)
             if nested:
-                return nested
-    return [t for t in tasks
-            if getattr(t, 'task_type', None) in _BLOCKING_TASK_TYPES
-            and getattr(t, 'status', None) in ('SCHEDULED', 'IN_PROGRESS')]
+                return nested, workflow
+    return ([t for t in tasks
+             if getattr(t, 'task_type', None) in _BLOCKING_TASK_TYPES
+             and getattr(t, 'status', None) in ('SCHEDULED', 'IN_PROGRESS')],
+            workflow)
 
 
 def _wait_for_blocking_task(workflow_executor: WorkflowExecutor, workflow_id: str,
@@ -771,24 +777,33 @@ def _wait_for_blocking_task(workflow_executor: WorkflowExecutor, workflow_id: st
     this needs to descend into nested sub-workflows rather than just checking
     the outer workflow's own task list.
 
-    Returns the tasks last seen so callers can report them if the wait times out.
+    Returns the blocking task(s) it found, or [] if the wait timed out. No
+    caller currently reads the return value; on timeout the diagnostic goes to
+    the log instead, since that is the only place the failure is visible.
     """
     deadline = time.time() + timeout
     tasks = []
+    workflow = None
     while time.time() < deadline:
-        tasks = _find_blocking_leaf_tasks(workflow_executor, workflow_id)
+        tasks, workflow = _find_blocking_leaf_tasks(workflow_executor, workflow_id)
         if tasks:
             return tasks
-        workflow = workflow_executor.get_workflow(workflow_id=workflow_id,
-                                                  include_tasks=False)
         if getattr(workflow, 'status', None) not in ('RUNNING', 'PAUSED'):
             # Already terminal: nothing is going to block, so stop waiting and
             # let the caller's assertion report the real state.
             break
         time.sleep(interval)
+    # Report the workflow's own last-seen state, not `tasks`: reaching here
+    # means the blocking-task filter came back empty, so logging `tasks` could
+    # only ever print [] -- which says nothing about *why* nothing blocked.
+    # What separates the cases is the outer workflow: still on its HTTP task,
+    # a SUB_WORKFLOW that never got decided, or already terminal.
     logger.warning(
-        'no blocking task on %s after %.0fs; tasks=%s', workflow_id, timeout,
-        [(getattr(t, 'task_def_name', '?'), getattr(t, 'status', '?')) for t in tasks])
+        'no blocking task on %s after %.0fs; workflow status=%s, tasks=%s',
+        workflow_id, timeout, getattr(workflow, 'status', '?'),
+        [(getattr(t, 'task_def_name', '?'), getattr(t, 'task_type', '?'),
+          getattr(t, 'status', '?'))
+         for t in (getattr(workflow, 'tasks', None) or [])])
     return tasks
 
 


### PR DESCRIPTION
Adds a second integration-test CI job that runs the suite against plain Conductor
OSS, alongside the existing authenticated run against the shared Orkes dev server.

`scripts/docker-compose-oss.yaml` brings up Conductor OSS + Postgres + httpbin, and
its `image:` line is the single place the default tag is written;
`scripts/run-integration-oss.sh` runs the same stack locally.

Orkes-Enterprise-only surface (Authorization, Secrets, Schema, Service Registry,
metadata/scheduler tags) is gated behind `CONDUCTOR_SERVER_TYPE=oss` and skips on
OSS. The Signal API tests do run on OSS, using WAIT-based fixture variants
(`complex_wf_signal_test_oss` and friends) — YIELD is Orkes-only, so the existing
fixtures never reach a signalable state there. A few call sites need an OSS-specific
path rather than a skip (archiving on delete, the missing `/workflow/{id}/status`,
create-with-`overwrite`); each is gated on OSS on purpose, so the Orkes path still
fails if the real behaviour regresses.

**Requires** the `E2E_TEST_OSS_CONDUCTOR_VERSION` org variable, with a repository
access policy that includes this repo. The new job fails fast if it can't resolve
an image tag — except on a fork PR, where GitHub withholds the variable and the job
falls through to the compose file's default rather than failing.

### Also fixes three latent bugs in the existing Orkes run

Running against a fresh, single-tenant server surfaced these. All three affect the
`integration-test` job too, not just the new one:

1. **`test_async.py` was clobbering another suite's task def** — it registered a bare
   `TaskDef` under `python_integration_test_task`, the name
   `test_workflow_execution.py` runs real workflows against. Those two run as
   concurrent CI jobs against one server, so last writer won, and a bare def gets the
   server's default 3600s `responseTimeoutSeconds` — so a stalled worker held the task
   for an hour and the workflow sat `IN_PROGRESS`. It now registers its own def instead.
2. **`run_workflow_execution_tests` never registered its task def** —
   `generate_tasks_defs()` was dead code, so the def was whatever another suite left
   behind. Registering it sets `response_timeout_seconds=2` (see 1) and makes the suite
   work on a fresh server.
3. **The Signal API tests signalled before the workflow was parked** —
   `_wait_for_blocking_task` matched any in-flight task, but the outer `SUB_WORKFLOW`
   flips to `IN_PROGRESS` before the nested workflow reaches its blocking task, so the
   signal raced the real block (intermittent "Expected BLOCKING_TASK, got None" / 404
   "Found no blocked task"). It now descends into running sub-workflows and matches
   only a non-terminal WAIT/YIELD task.

### Also

- Server-flavour checks route through one `is_oss()` helper instead of 9 open-coded
  env reads, 4 of them inverted.
- `test_task_metadata_service.py` gains a `tearDownClass` — its defs used to be left
  behind, so re-runs hit "already exists".
- Fixture owner emails use the `test@conductoross.io` placeholder csharp-sdk settled
  on for this ticket, not real employee addresses.
- `run-integration-oss.sh` and the CI job both pull the image unconditionally so a
  cached mutable tag isn't reused; OSS health wait 120s → 180s; `workflow_dispatch`
  gains an `oss_conductor_version` input.


