### PR TITLE
Fix e2e LLM-judge call for anthropic SDK 1.x

### DIFF
--- a/e2e/test_suite1_basic_validation.py
+++ b/e2e/test_suite1_basic_validation.py
@@ -365,7 +365,7 @@ def _judge_call_anthropic(model: str, system: str, user: str) -> str:
         max_tokens=1024,
         system=system,
         messages=[{"role": "user", "content": user}],
-        temperature=0,
+        extra_body={"temperature": 0},
     )
     return response.content[0].text.strip()
 


### PR DESCRIPTION
`anthropic` 1.0.0 removed `temperature` from `messages.create()`, so `test_llm_judge_validates_compiled_workflow` failed with `TypeError: Messages.create() got an unexpected keyword argument 'temperature'`.

Passes it through `extra_body` instead, per the SDK migration guide: https://github.com/anthropics/anthropic-sdk-python/blob/main/MIGRATION.md#removed-deprecated-request-parameters

```
# Before
client.messages.create(..., model="claude-sonnet-4-6", temperature=0.2)

# After
client.messages.create(..., model="claude-sonnet-4-6", extra_body={"temperature": 0.2})
```

**Why it broke with no code change:** `pyproject.toml` declares `anthropic = ">=0.91.0"` with no upper bound, so CI resolves the latest release. `0.125.0` (published 2026-08-19) works; `1.0.0` (2026-08-20) does not. CI picked up 1.0.0 on the next run while local envs on 0.x kept passing.

Verified locally against a live server — test passes.